### PR TITLE
Cart qty fix

### DIFF
--- a/snippets/ajax-cart-template.liquid
+++ b/snippets/ajax-cart-template.liquid
@@ -7,7 +7,7 @@
 {% endcomment %}
   <script id="cartTemplate" type="text/template">
   {% raw %}
-    <form action="/cart" method="post">
+    <form action="/cart" method="post" novalidate>
       <button class="ajaxifyCart--close" title="Close Cart">Close Cart</button>
       <div class="ajaxifyCart--products">
         {{#items}}
@@ -22,7 +22,7 @@
             </div>
             <div class="ajaxifyCart--col2">
               <div class="ajaxifyCart--qty">
-                <input type="text" class="ajaxifyCart--num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity">
+                <input type="text" class="ajaxifyCart--num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity" pattern="[0-9]*">
                 <span class="ajaxifyCart--qty-adjuster ajaxifyCart--add" data-id="{{id}}" data-qty="{{itemAdd}}">+</span>
                 <span class="ajaxifyCart--qty-adjuster ajaxifyCart--minus" data-id="{{id}}" data-qty="{{itemMinus}}">-</span>
               </div>
@@ -69,7 +69,7 @@
   <script id="ajaxifyQty" type="text/template">
   {% raw %}
     <div class="ajaxifyCart--qty">
-      <input type="text" class="ajaxifyCart--num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity">
+      <input type="text" class="ajaxifyCart--num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity" pattern="[0-9]*">
       <span class="ajaxifyCart--qty-adjuster ajaxifyCart--add" data-id="{{id}}" data-qty="{{itemAdd}}">+</span>
       <span class="ajaxifyCart--qty-adjuster ajaxifyCart--minus" data-id="{{id}}" data-qty="{{itemMinus}}">-</span>
     </div>

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -14,7 +14,7 @@
 </header>
 
 {% if cart.item_count > 0 %}
-  <form action="/cart" method="post">
+  <form action="/cart" method="post" novalidate>
 
     <div class="cart-row medium-down--hide">
       <div class="grid">


### PR DESCRIPTION
Adding `novalidate` ensures the ajax quantity selector's pattern attribute (used to force a number keyboard on iOS) does not prevent the form from submitting.
