### PR TITLE
If the toggle button doesn't exist, don't get it's offset

### DIFF
--- a/assets/ajaxify.js
+++ b/assets/ajaxify.js
@@ -474,12 +474,14 @@ var ajaxifyShopify = (function(module, $) {
 
     // Position the caret
     function positionCaret() {
-      // Get the position of the toggle button to align the carat with
-      var togglePos = $toggleCartButton.offset(),
-          toggleWidth = $toggleCartButton.outerWidth(),
-          toggleMiddle = togglePos.left + toggleWidth/2;
+      if ($toggleCartButton.offset()) {
+        // Get the position of the toggle button to align the carat with
+        var togglePos = $toggleCartButton.offset(),
+            toggleWidth = $toggleCartButton.outerWidth(),
+            toggleMiddle = togglePos.left + toggleWidth/2;
 
-      $drawerCaret.css('left', toggleMiddle + 'px');
+        $drawerCaret.css('left', toggleMiddle + 'px');
+      }
     }
   };
 


### PR DESCRIPTION
If the element is defined but has no offset, there is nothing to measure and breaks the JS. This checks to make sure an offset exists.
