### PR TITLE
Removed option to disable open graph and twitter cards

### DIFF
--- a/config/settings.html
+++ b/config/settings.html
@@ -32,24 +32,13 @@
   <legend>Social Meta Tags</legend>
   <table>
     <tr>
-      <td colspan="2"><small>Social helpers include Facebook Open Graph Tags and Twitter Cards. Enable or disable them here, all of the code is taking care of for you in snippets.</small></td>
-    </tr>
-    <tr>
-      <td><label for="enable_opengraph">Enable <a href="https://developers.facebook.com/docs/opengraph/using-objects/" title="About Facebook Open Graph Objects">Facebook</a> and <br /><a href="https://developers.pinterest.com/rich_pins/" title="About Pinterest Rich Pins">Pinterest</a> Open Graph tags</label></td>
-      <td>
-        <input type="checkbox" id="enable_opengraph" name="enable_opengraph" />
-        <small>Open Graph tags are used by Facebook and Pinterest to load the appropriate product details when sharing or pinning.</small>
-      </td>
-    </tr>
-    <tr>
-      <td><label for="enable_twittercards">Enable <a href="https://dev.twitter.com/docs/cards/types/product-card" title="About Twitter Product Cards">Twitter Cards</a></label></td>
-      <td><input type="checkbox" id="enable_twittercards" name="enable_twittercards" /></td>
+      <td colspan="2"><small>Social meta tags include <a href="https://developers.facebook.com/docs/opengraph/using-objects/" title="About Facebook Open Graph Objects">Facebook</a> and <a href="https://developers.pinterest.com/rich_pins/" title="About Pinterest Rich Pins">Pinterest</a> Open Graph Tags and <a href="https://dev.twitter.com/docs/cards/types/product-card" title="About Twitter Product Cards">Twitter Cards</a>. These are enabled by default to make your store more accessible on different platforms. Add any required information below for them to rendor properly.</small></td>
     </tr>
     <tr>
       <th><label for="twittercard_handle">Your site's Twitter Handle</label></th>
       <td>
         <input type="text" id="twittercard_handle" name="twittercard_handle" value="" /><br />
-        <small>E.g. @Shopify. Required if Twitter Cards are enabled.</small>
+        <small>E.g. @Shopify. Required for Twitter Cards.</small>
       </td>
     </tr>
   </table>

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -3,8 +3,6 @@
   "presets": {
     "Default": {
       "use_logo": false,
-      "enable_opengraph": true,
-      "enable_twittercards": true,
       "customer_layout": "theme",
       "footer_display_contact": true,
       "footer_contact_title": "Contact Us",

--- a/snippets/fb-open-graph-tags.liquid
+++ b/snippets/fb-open-graph-tags.liquid
@@ -14,7 +14,6 @@
     - https://developers.pinterest.com/rich_pins/validator/
 
 {% endcomment %}
-{% if settings.enable_opengraph %}
 {% if template contains 'product' %}
   <meta property="og:type" content="product">
   <meta property="og:title" content="{{ product.title | strip_html | escape }}">
@@ -46,7 +45,6 @@
 {% endif %}
 {% if page_description %}
   <meta property="og:description" content="{{ page_description | escape }}">
-{% endif %}
 {% endif %}
   <meta property="og:url" content="{{ canonical_url }}">
   <meta property="og:site_name" content="{{ shop.name }}">

--- a/snippets/twitter-card.liquid
+++ b/snippets/twitter-card.liquid
@@ -12,8 +12,6 @@
 
 {% endcomment %}
 
-{% if settings.enable_twittercards %}
-
 {% comment %}
   Twitter user name of the site, based on theme settings
 {% endcomment %}
@@ -51,6 +49,4 @@
     <meta property="twitter:image" content="{{ src }}">
     {% endif %}
   {% endif %}
-{% endif %}
-
 {% endif %}


### PR DESCRIPTION
All shops should use Facebook/Pinterest open graph tags and Twitter Cards to be more accessible on more platforms. Option to disable them has been removed.
