### PR TITLE
Schema logo

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -71,15 +71,23 @@
           {% comment %}
             Use the uploaded logo from theme settings if enabled
           {% endcomment %}
-          <h1 class="header-logo large--left">
+          {% if template == 'index' %}
+            <h1 class="header-logo large--left" itemscope itemtype="http://schema.org/Organization">
+          {% else %}
+            <div class="header-logo large--left" itemscope itemtype="http://schema.org/Organization">
+          {% endif %}
             {% if settings.use_logo %}
-              <a href="/">
-                {{ 'logo.png' | asset_url | img_tag: shop.name }}
+              <a href="/" itemprop="url">
+                <img src="{{ 'logo.png' | asset_url }}" alt="{{ shop.name }}" itemprop="logo">
               </a>
             {% else %}
-              <a href="/">{{ shop.name }}</a>
+              <a href="/" itemprop="url">{{ shop.name }}</a>
             {% endif %}
-          </h1>
+          {% if template == 'index' %}
+            </h1>
+          {% else %}
+            </div>
+          {% endif %}
         </div>
         <div class="grid-item large--one-half text-center large--text-right">
           {% comment %}


### PR DESCRIPTION
Adjusted site logo to use [schema markup](http://googlewebmastercentral.blogspot.com.au/2013/05/using-schemaorg-markup-for-organization.html).

Also, only the home page shows this as `<h1>`, all other pages use `<div>`
