### PR TITLE
Link to remove type/vendor don't return links. Remove them

### DIFF
--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -32,7 +32,7 @@
     {% for type in collection.all_types %}
       {% if collection.current_type == type %}
         <li class="active-filter">
-          {{ type | link_to_remove_type }}
+          {{ type }}
         </li>
       {% else %}
         <li>
@@ -60,7 +60,7 @@
     {% for vendor in collection.all_vendors %}
       {% if collection.current_vendor == vendor %}
         <li class="active-filter">
-          {{ vendor | link_to_remove_vendor }}
+          {{ vendor }}
         </li>
       {% else %}
         <li>


### PR DESCRIPTION
Types and vendors don't act the same as tags, so `link_to_remove_type` and `link_to_remove_vendor` do not generate links. Non-breaking change.

Thanks @terkelg

Fixes #91 
