### PR TITLE
match grid example and grid code in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,6 @@ $breakpoints: (
   &lt;/div&gt;
   
   &lt;div class="grid-item"&gt;
-  
     &lt;div class="grid"&gt;
       
       &lt;div class="grid-item large--one-half medium--one-third"&gt;
@@ -354,12 +353,10 @@ $breakpoints: (
     
     &lt;/div&gt;
     // End sub grid
-    
   &lt;/div&gt;
   // End grid-item
 
   &lt;div class="grid-item"&gt;
-  
     &lt;div class="grid"&gt;
 
       &lt;div class="grid-item large--one-twelfth one-sixth small--one-third"&gt;
@@ -412,7 +409,6 @@ $breakpoints: (
       
     &lt;/div&gt;
     // End sub grid
-    
   &lt;/div&gt;
   // End grid-item
 


### PR DESCRIPTION
moved grid example tab classes and structure to grid example code tab for consistent demo
fixed reference error 2.12 in grid example tab, should be 3.12
