### PR TITLE
Updated JS to handle grid/list view changes

### DIFF
--- a/snippets/collection-views.liquid
+++ b/snippets/collection-views.liquid
@@ -13,6 +13,15 @@
 </div>
 
 <script>
+  function replaceUrlParam(url, paramName, paramValue) {
+    var pattern = new RegExp('('+paramName+'=).*?(&|$)'),
+        newUrl = url.replace(pattern,'$1' + paramValue + '$2');
+    if ( newUrl == url ) {
+      newUrl = newUrl + (newUrl.indexOf('?')>0 ? '&' : '?') + paramName + '=' + paramValue;
+    }
+    return newUrl;
+  }
+
   $(function() {
     $('.change-view').on('click', function() {
       var view = $(this).data('view'),
@@ -20,7 +29,7 @@
           hasParams = url.indexOf('?') > -1;
 
       if (hasParams) {
-        window.location = url + '&view=' + view;
+        window.location = replaceUrlParam(url, 'view', view);
       } else {
         window.location = url + '?view=' + view;
       }


### PR DESCRIPTION
When toggling between grid and list views on the collection pages, the URL would continue to grow even if a `view` parameter already existed.

Eg. `accessories?view=list&view=grid&view=list&view=grid&view=list&view=grid&view=grid&view=list&view=grid`

The updated JS replaces the `view` parameter if it already exists.
