### PR TITLE
Add .inline-list example to list table in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1354,6 +1354,20 @@ jQuery(function($) {
             </tr>
             <tr>
               <td>
+                <h6>Inline List <code>ul</code></h6>
+                <code>.inline-list</code>
+              </td>
+              <td>
+                <ul class="inline-list">
+                  <li>One</li>
+                  <li>Two</li>
+                  <li>Three</li>
+                  <li>Four</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>
                 <h6>Numeric bullet <code>ol</code> (default)</h6>
               </td>
               <td>


### PR DESCRIPTION
class `.inline-list` already exists in theme.scss.liquid, so make example of use in docs
