### PR TITLE
add user feedback on qty update ajax drawer

### DIFF
--- a/assets/ajaxify.js
+++ b/assets/ajaxify.js
@@ -666,6 +666,8 @@ var ajaxifyShopify = (function(module, $) {
         buildCart(cart);
         if ( !$drawerContainer.hasClass('is-visible') ) {
           showDrawer();
+        } else {
+          scrollTop();
         }
         break;
     }


### PR DESCRIPTION
add scrollTop() if user updates quantity outside of cart drawer when cart drawer is-visible

There is no obvious close button on ajax cart drawer so user naturally scrolls down.  user could click Cart link to close the drawer or simply keep scrolling and leave drawer visible.  In this case, if user then adds item or updates quantity to cart from 'Add to Cart' button there is no user feedback that the item was added.

If the user checks drawer after page load, leaves open, and then adds a new item on same page, then visible drawer expands a bit pushing down page and exposing a bit of drawer into view at top (probably not intended experience).  If it is a quantity change of an item already in cart, then no feedback/movement.  There are probably many routes to address this:
- Add a more natural close button to the cart Drawer so user inclined to close
- Add a feedback state when Add to Cart is clicked so user knows something happened
- Add scrollTop() on callback when cart is visible and quantity changes

I figured the easiest was the latter, and this patch addresses that.  Please check.
