### PR TITLE
correct class typos in `pre` for buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1617,15 +1617,15 @@ jQuery(function($) {
 <pre>
 &lt;!-- Primary --&gt;
 &lt;a href="#" class="btn"&gt;Default Button&lt;/a&gt;
-&lt;a href="#" class="btn small"&gt;Small Default Button&lt;/a&gt;
+&lt;a href="#" class="btn btn--small"&gt;Small Default Button&lt;/a&gt;
 &lt;!-- Secondary --&gt;
 &lt;a href="#" class="btn-secondary"&gt;Secondary Button&lt;/a&gt;
-&lt;a href="#" class="btn-secondary small"&gt;Small Default Button&lt;/a&gt;
+&lt;a href="#" class="btn-secondary btn--small"&gt;Small Default Button&lt;/a&gt;
 &lt;!-- Disabled --&gt;
 &lt;a href="#" class="btn disabled"&gt;Disabled Button&lt;/a&gt;
-&lt;a href="#" class="btn disabled small"&gt;Small Disabled Button&lt;/a&gt;
+&lt;a href="#" class="btn disabled btn--small"&gt;Small Disabled Button&lt;/a&gt;
 &lt;!-- Sized --&gt;
-&lt;a href="#" class="btn full"&gt;Wide Button&lt;/a&gt;
+&lt;a href="#" class="btn btn--full"&gt;Wide Button&lt;/a&gt;
 </pre>
         </div>
 


### PR DESCRIPTION
classes in button code examples lacked the leading `btn--` before size modifiers
