### PR TITLE
Remove aria-hidden nav toggle

### DIFF
--- a/assets/shop.js.liquid
+++ b/assets/shop.js.liquid
@@ -46,7 +46,6 @@ timber.accessibleNav = function () {
   // Blur
   allLinks.blur(function(e) {
     topLevel.removeClass('nav-focus');
-    subMenus.attr('aria-hidden', 'true');
   });
 
   // accessibleNav private methods
@@ -61,16 +60,6 @@ timber.accessibleNav = function () {
       el.addClass('nav-focus');
     } else {
       el.closest('.site-nav--has-dropdown').find('a').addClass('nav-focus');
-      el.closest('.site-nav--dropdown').attr('aria-hidden', 'false');
-    }
-
-    // Toggle aria-hidden attribute for top level items
-    if ( hasSubMenu ) {
-      if (subMenu.attr('aria-hidden') == 'true') {
-        subMenu.attr('aria-hidden', 'false');
-      } else {
-        subMenu.attr('aria-hidden', 'true');
-      }
     }
 
   }

--- a/snippets/site-nav.liquid
+++ b/snippets/site-nav.liquid
@@ -16,7 +16,7 @@
     {% if linklists[child_list_handle].links != blank %}
       <li class="site-nav--has-dropdown{% if link.active %} site-nav--active{% endif %}" aria-haspopup="true">
         <a href="{{ link.url }}">{{ link.title }}</a>
-        <ul class="site-nav--dropdown" aria-hidden="true">
+        <ul class="site-nav--dropdown">
           {% for childlink in linklists[child_list_handle].links %}
             <li {% if childlink.active %}class="site-nav--active"{% endif %}><a href="{{ childlink.url }}">{{ childlink.title | escape }}</a></li>
           {% endfor %}


### PR DESCRIPTION
Toggling an element's `aria-hidden` while also toggling `display: none/block` or `visibility: hidden/visible` is redundant. `aria-hidden` is only necessary to prevent screen reader access to elements that are not hidden (display/visibility).

cc/ @mpiotrowicz
