### PR TITLE
add min-height 1px to `.grid-item`

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -309,6 +309,7 @@ $class-type: unquote(".");
 
 #{$class-type}grid-item {
   float: left;
+  min-height: 1px;
   padding-left:$gridGutter;
   vertical-align:top;
   @if $mobile-first == true {


### PR DESCRIPTION
prevents empty `.grid-item` div from collapsing
