### PR TITLE
Scroll top when adding product. Classes for styling

### DIFF
--- a/assets/ajaxify.js
+++ b/assets/ajaxify.js
@@ -619,6 +619,9 @@ var ajaxifyShopify = (function(module, $) {
     $formContainer.submit(function(e) {
       e.preventDefault();
 
+      // Add class to be styled if desired
+      $addToCart.removeClass('is-added').addClass('is-adding');
+
       // Remove any previous quantity errors
       $('.qty-error').remove();
 
@@ -634,6 +637,8 @@ var ajaxifyShopify = (function(module, $) {
   };
 
   itemAddedCallback = function (product) {
+    $addToCart.removeClass('is-adding').addClass('is-added');
+
     // Slight delay of flip to mimic a longer load
     switch (settings.method) {
       case 'flip':
@@ -675,6 +680,8 @@ var ajaxifyShopify = (function(module, $) {
         buildCart(cart);
         if ( !$drawerContainer.hasClass('is-visible') ) {
           showDrawer();
+        } else {
+          scrollTop();
         }
         break;
     }


### PR DESCRIPTION
Addresses #130.
- User is scrolled to the top of the page when adding a new product, even if the cart drawer is already visible.
- Add `is-adding` and `is-added` classes to `addToCartSelector`. Designers/devs can style as they wish.
