### PR TITLE
variants.size is never zero

### DIFF
--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -70,13 +70,10 @@
               <h5>
                 <a href="{{ item.product.url }}">
                   {{ item.product.title }}
-
-                  {% if item.product.variants.size != 0 %}
-                    {% unless item.variant.title contains 'Default' %}
-                      <br>
-                       <small>{{ item.variant.title }}</small>
-                    {% endunless %}
-                  {% endif %}
+                  {% unless item.variant.title contains 'Default' %}
+                    <br>
+                    <small>{{ item.variant.title }}</small>
+                  {% endunless %}
                 </a>
               </h5>
 


### PR DESCRIPTION
- There is at least one variant for all products.
- Products with only 1 variant may still want to show their 1 variant
  title, e.g. one of a kind vintage clothes that come in one size only, and merchants want to show the size.
- item.title does what you want except does not allow you to style the variant part of the line item title.

@cshold 
