### PR TITLE
Add jQuery selectors to doc ready

### DIFF
--- a/assets/shop.js.liquid
+++ b/assets/shop.js.liquid
@@ -1,6 +1,6 @@
 window.timber = window.timber || {};
 
-$(function() {
+timber.cacheSelectors = function () {
   timber.cache = {
     // General
     $html: $('html'),
@@ -12,13 +12,12 @@ $(function() {
     // Product Page
     $mainImage: $('#productPhotoImg'),
     $thumbImages: $('#productThumbs').find('a.product-photo-thumb'),
-    $newImage: null
+    newImage: null
   }
-});
+}
 
 timber.init = function () {
-
-  // Run on load
+  timber.cacheSelectors();
   timber.accessibleNav();
   timber.productImageSwitch();
 }
@@ -111,12 +110,10 @@ timber.productImageSwitch = function () {
   // Note: this does not change the variant selected, just the image
   timber.cache.$thumbImages.on('click', function(e) {
     e.preventDefault();
-    timber.cache.$newImage = $(this).attr('href');
-    timber.cache.$mainImage.attr({ src: timber.cache.$newImage });
+    timber.cache.newImage = $(this).attr('href');
+    timber.cache.$mainImage.attr({ src: timber.cache.newImage });
   });
 }
 
 // Initialize Timber's JS on docready
-$(function() {
-  window.timber.init();
-});
+$(timber.init)


### PR DESCRIPTION
I noticed that the jQuery selectors weren't working if I included them before or directly after including jQuery. Is this the best way to make sure that doesn't happen, @richgilbank @gavinsmith?
