### PR TITLE
Don't show type if product is hidden

### DIFF
--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -27,14 +27,27 @@
 <h3>Product Types</h3>
   <ul>
     {% for type in collection.all_types %}
-      {% if collection.current_type == type %}
-        <li class="active-filter">
-          {{ type }}
-        </li>
-      {% else %}
-        <li>
-          {{ type | link_to_type }}
-        </li>
+      {% comment %}
+        Set a flag so we don't show types for hidden products
+      {% endcomment %}
+      {% assign hidden = true %}
+      {% for product in collection.all_products %}
+        {% if product.type == type %}
+          {% if product.available %}
+            {% assign hidden = false %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {% if hidden == false %}
+        {% if collection.current_type == type %}
+          <li class="active-filter">
+            {{ type }}
+          </li>
+        {% else %}
+          <li>
+            {{ type | link_to_type }}
+          </li>
+        {% endif %}
       {% endif %}
     {% endfor %}
   </ul>
@@ -81,29 +94,25 @@
     <li{% unless current_tags %} class="active-filter"{% endunless %}>
 
       {% comment %}
-        Good for /collections/all collection and regular collections
+        /collections/all collection and regular collections
       {% endcomment %}
       {% if collection.handle %}
         <a href="/collections/{{ collection.handle }}">All {{ collection.title }}</a>
 
       {% comment %}
-        Good for automatic type collections
+        Automatic type collections
       {% endcomment %}
       {% elsif collection.current_type %}
         <a href="{{ collection.current_type | url_for_type }}">All {{ collection.title }}</a>
 
       {% comment %}
-        Good for automatic vendor collections
+        Automatic vendor collections
       {% endcomment %}
       {% elsif collection.current_vendor %}
         <a href="{{ collection.current_vendor | url_for_vendor }}">All {{ collection.title }}</a>
-
       {% endif %}
     </li>
 
-    {% comment %}
-      And for the good stuff, loop through the tags themselves.
-    {% endcomment %}
     {% for tag in collection.all_tags %}
       {% if current_tags contains tag %}
         <li class="active-filter">


### PR DESCRIPTION
If all products with a `type` are hidden, it still shows up in the `for type in collections.all_types` list.

Thoughts on this approach for making sure it doesn't show up in the list?

Steps during `for type in collection.all_types` loop:
1. Set a flag `hidden = true` - default to hiding the `type`
2. Loop through _all_ products
3. If the current product's `type` = current `type, continue
4. If the product is available, set the hidden flag to false

Potential issues, I don't have the answers to:
1. Is there a performance hit if we loop through all products like this?
2. Is there any case this would hide a type by accident? (maybe because of collections.all_products pagination limit)
3. Should Timber take this into account, or put the onus on the merchant?
4. I can't figure out a similar approach to hiding tags for hidden products.

@carolineschnapp @fredryk 
