### PR TITLE
Minor JS cart fixes

### DIFF
--- a/assets/ajaxify.js
+++ b/assets/ajaxify.js
@@ -591,6 +591,7 @@ var ajaxifyShopify = (function(module, $) {
       $drawerContainer.css('height', '0px');
     } else {
       $drawerHeight = $cartContainer.outerHeight();
+      $('.cart-row img').css('width', 'auto'); // fix Chrome image size bug
       $drawerContainer.css('height',  $drawerHeight + 'px');
     }
   };

--- a/assets/ajaxify.scss.liquid
+++ b/assets/ajaxify.scss.liquid
@@ -210,7 +210,7 @@ form[action^="/cart/add"] {
     overflow: hidden;
     opacity: 0;
     padding: 0;
-    margin: -$gutter 0 0;
+    margin: -15px 0 0;
     visibility: hidden;
     @include transform('rotateX(-92deg)');
     @include backface(hidden);

--- a/assets/shop.js.liquid
+++ b/assets/shop.js.liquid
@@ -117,8 +117,8 @@ timber.productImageSwitch = function () {
 }
 
 timber.responsiveVideos = function () {
-  $('iframe[src*="youtube.com/embed"').wrap('<div class="video-wrapper"></div>');
-  $('iframe[src*="player.vimeo"').wrap('<div class="video-wrapper"></div>');
+  $('iframe[src*="youtube.com/embed"]').wrap('<div class="video-wrapper"></div>');
+  $('iframe[src*="player.vimeo"]').wrap('<div class="video-wrapper"></div>');
 }
 
 // Initialize Timber's JS on docready

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1180,12 +1180,7 @@ svg:not(:root) {
 }
 
 img.auto,
-.grid-item img {
-  max-width: 100%;
-  max-height: 100%;
-  height: auto;
-}
-
+.grid-item img,
 .grid-item iframe {
   max-width: 100%;
 }

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -58,7 +58,7 @@
               {% comment %}
                 Optional, add the vendor
               {% endcomment %}
-              Vendor: <em>{{ item.vendor }}</em>
+              <p>Vendor: <em>{{ item.vendor }}</em></p>
 
               {% comment %}
                 Optional, loop through custom product line items if available


### PR DESCRIPTION
For reasons I can't put a finger on, Chrome (36) doesn't let images define their own width in hidden elements. A repaint fixes the layout issue, so clicking _Check Out_ broke the layout as the images became taller suddenly.

Line 594 of `ajaxify.js` forces the repaint just before we show the cart, and fixes the image layout issue. It's hacky at best.
- Also fixed jQuery selectors that were invalid in Firefox
- Removed max-height definition on all images in the grid

Fixes #167 
