### PR TITLE
Remove unhelpful grid helper classes

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -366,29 +366,6 @@ $class-type: unquote(".");
   }
 }
 
-/* Align the entire grid to the right. */
-#{$class-type}grid--right {
-  @extend #{$class-type}grid;
-  direction:rtl;
-  text-align:right;
-
-  > #{$class-type}grid-item {
-    direction:ltr;
-    float: right;
-    text-align:left;
-  }
-}
-
-/* Centered grids align grid items centrally without needing to use push or pull classes. */
-#{$class-type}grid--center {
-  @extend #{$class-type}grid;
-  text-align:center;
-
-  > #{$class-type}grid-item {
-    text-align:left;
-  }
-}
-
 /*============================================================================
   WIDTHS
     - Create width classes, prefixed by the specified namespace.


### PR DESCRIPTION
Since we're floating block elements, `.grid--right` and `.grid--center` were unusable helper classes.

Fixes #170 
