### PR TITLE
make search bar button a button

### DIFF
--- a/snippets/search-bar.liquid
+++ b/snippets/search-bar.liquid
@@ -21,6 +21,6 @@
 
   <input type="search" name="q" value="{{ search.terms | escape }}" placeholder="Search our store" class="input-group-field" aria-label="Search our store">
   <span class="input-group-btn">
-    <input type="submit" class="btn" value="Search">
+    <button type="submit" class="btn">Search</button>
   </span>
 </form>


### PR DESCRIPTION
make the search bar button an actual button; allows in future for easier span/icon inclusion in button
