### PR TITLE
Fixed CSS table layouts

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -692,16 +692,21 @@ body {
 
 .display-table {
   display: table;
+  table-layout: fixed;
+  width: 100%;
 }
 
 .display-table-cell {
   display: table-cell;
   vertical-align: middle;
+  float: none;
 }
 
 @include at-query ($min, $large) {
   .large--display-table {
     display: table;
+    table-layout: fixed;
+    width: 100%;
   }
 
   .large--display-table-cell {
@@ -1694,6 +1699,7 @@ label.error {
   @include at-query ($min, $large) {
     .grid {
       display: table;
+      table-layout: fixed;
       width: 100%;
 
       & > .grid-item {
@@ -1870,6 +1876,7 @@ label.error {
 
 .product-grid-item {
   display: block;
+  text-decoration: none;
 }
 
 .product-grid-image {


### PR DESCRIPTION
- CSS `display: table` has some issues in IE and Firefox when not set to 100% width
- It also helps to include `table-layout: fixed` to avoid [this sizing inconsistency](http://www.carsonshold.com/2014/07/css-display-table-cell-child-width-bug-in-firefox-and-ie/)

@stevebosworth
