### PR TITLE
Allow param to set ajax cart method

### DIFF
--- a/assets/ajaxify.js
+++ b/assets/ajaxify.js
@@ -284,13 +284,13 @@ var ajaxifyShopify = (function(module, $) {
     // Override defaults with arguments
     $.extend(settings, options);
 
-    // Make sure method is lower case
-    settings.method = settings.method.toLowerCase();
-
     // If method parameter is set, override the defined method (used for demos)
     if ( urlParams('method') ) {
       settings.method = urlParams('method');
     }
+
+    // Make sure method is lower case
+    settings.method = settings.method.toLowerCase();
 
     // Select DOM elements
     $formContainer     = $(settings.formSelector);


### PR DESCRIPTION
Read the `method` parameter, and if set, override the ajax cart method. Only valid methods are:
- `drawer`
- `modal`
- `flip`

[Demo flip](https://timber-demo.myshopify.com/products/true-flatlock-mens-tee-1?method=flip)
[Demo drawer](https://timber-demo.myshopify.com/products/true-flatlock-mens-tee-1?method=drawer)
[Demo modal](https://timber-demo.myshopify.com/products/true-flatlock-mens-tee-1?method=modal)

Navigating to a new page will remove the parameter and revert to the default `drawer`.

Fixes #158 

@Shopify/fed @carolineschnapp 
