### PR TITLE
blog.liquid pagination conflicts

### DIFF
--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -1,12 +1,3 @@
-{% comment %}
-
-  Loop through a defined number of articles with the 'paginate' tag.
-  Don't forget to close the tag after your loop.
-
-{% endcomment %}
-
-{% paginate blog.articles by 5 %}
-
 {% include 'breadcrumb' %}
 
 {% comment %}
@@ -29,11 +20,17 @@
     {% endif %}
 
     {% comment %}
-      Loop through each article in your blog. This is limited to what you set for pagination above.
+    
+      Loop through a defined number of articles with the 'paginate' tag.
+      Don't forget to close the tag after your loop.
+      Then, loop through each article in your blog limited to what you set for pagination.
 
       For more info on article liquid tags:
         - http://docs.shopify.com/themes/liquid-variables/article
+    
     {% endcomment %}
+    
+    {% paginate blog.articles by 5 %}
 
     {% for article in blog.articles %}
 
@@ -89,8 +86,8 @@
     </div>
     {% endif %}
 
+    {% endpaginate %}
+
   </div>
 
 </div>
-
-{% endpaginate %}


### PR DESCRIPTION
blog-sidebar is being affected when it is contained within pagination -- this restructures blog.liquid for pagination to exclude the blog-sidebar snippet.

if pagination includes blog-sidebar then the loop of articles within the blog-sidebar is affected:
1. **Relatively** If on page two of blog pagination then the sidebar of 'Recent Articles' is looping through only the blog articles on that page; thus not truly showing the recent articles of the entire blog, only re-listing the items on that page.
2. **Limited** If the pagination is set to 5 but the blog-sidebar articles loop is set to limit: 6 then only 5 items will show up in the sidebar Recent article because pagination supersedes limit.  However, if you view same sidebar on the articles page then 6 will show up, because now the loops is not affected by the blog.liquid pagination.

I rearranged the comments to try and streamline also -- but ultimately you may decide to reject the PR and organize better
