### PR TITLE
I18n form fix

### DIFF
--- a/templates/page.contact.liquid
+++ b/templates/page.contact.liquid
@@ -32,7 +32,7 @@
         {% endcomment %}
         {% if form.posted_successfully? %}
           <p class="note form-success">
-            {{ 'contact.post.success' | t }}
+            {{ 'contact.form.post_success' | t }}
           </p>
         {% endif %}
 


### PR DESCRIPTION
Take note that only 'email' and 'body' are validated in the contact
form, so we must use a name attribute set to 'email' and 'body'
respectively for those. Every other field can use any other name
attribute. Shopify has no particular concept of a 'phone' field or
'name' field. So use localization there! These fields end up in the email sent to the merchant, who will appreciate having those in his/her own language. 

Also I added placeholder translations, since the contact form fields were re-using the label as
placeholder, which I think may have been “lazy”-ish of us.

@cshold @jonasll 
