### PR TITLE
collection description on collection.list.liquid

### DIFF
--- a/templates/collection.list.liquid
+++ b/templates/collection.list.liquid
@@ -29,15 +29,32 @@
 
   <div class="grid-item large--three-quarters">
 
+    {% comment %}
+      Different markup if a collection description exists
+    {% endcomment %}
+    {% if collection.description != blank %}
+      <header class="section-header">
+        <h1 class="section-header--title">{{ collection.title }}</h1>
+        <div class="rte rte--header">
+          {{ collection.description }}
+        </div>
+      </header>
+      <hr>
+      <div class="section-header">
+        <div class="section-header--right">
+          {% include 'collection-sorting' %}
+          {% include 'collection-views' %}
+        </div>
+      </div>
+    {% else %}
     <header class="section-header">
-      <h1 class="section-header--left">{{ collection.title }}</h1>
+      <h1 class="section-header--title section-header--left">{{ collection.title }}</h1>
       <div class="section-header--right">
-
         {% include 'collection-sorting' %}
         {% include 'collection-views' %}
-
       </div>
     </header>
+    {% endif %}
 
     {% comment %}
       Use class grid-uniform to have evenly sized columns clear


### PR DESCRIPTION
looks like description got left out of collection.list.liquid when it was moved from sidebar to standard collection.liquid; this brings over same markup from collection.liquid (i.e. NOTE classes in block are also different from current collection.list.liquid)
