### PR TITLE
product loop classes

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1906,12 +1906,13 @@ label.error {
 
 }
 
+.product-list-item,
 .product-grid-item {
   display: block;
   text-decoration: none;
 }
 
-.product-grid-image {
+.product-loop-image {
   display: block;
   margin: 0 auto $gutter/2;
 

--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -46,7 +46,7 @@
 {% comment %}
   Set a class for sold-out and on-sale items
 {% endcomment %}
-<div class="grid-item {{grid_item_width}}{% if sold_out %} sold-out{% endif %}{% if on_sale %} on-sale{% endif %}">
+<div class="grid-item {{grid_item_width}}{% if sold_out %} sold-out{% endif %}{% if on_sale %} on-sale{% endif %} product-grid-item">
 
   {% comment %}
     Link to your product with the 'within: collection' filter for the link to be aware of the collection.
@@ -60,7 +60,7 @@
       - http://docs.shopify.com/support/your-store/collections/how-to-navigate-within-a-collection
 
   {% endcomment %}
-  <a href="{{ product.url | within: collection }}" class="product-grid-image">
+  <a href="{{ product.url | within: collection }}" class="product-loop-image">
     <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
   </a>
 

--- a/snippets/product-list-item.liquid
+++ b/snippets/product-list-item.liquid
@@ -30,7 +30,7 @@
 {% comment %}
   Set a class for sold-out and on-sale items
 {% endcomment %}
-<div class="grid-item{% if sold_out %} sold-out{% endif %}{% if on_sale %} on-sale{% endif %}">
+<div class="grid-item{% if sold_out %} sold-out{% endif %}{% if on_sale %} on-sale{% endif %} product-list-item">
 
   {% comment %}
     Link to your product with the 'within: collection' filter for the link to be aware of the collection.
@@ -44,35 +44,37 @@
       - http://docs.shopify.com/support/your-store/collections/how-to-navigate-within-a-collection
 
   {% endcomment %}
-  <a href="{{ product.url | within: current_collection }}" class="product-grid-item">
-    <div class="grid large--display-table">
-      <div class="grid-item large--one-fifth large--display-table-cell medium--one-third">
+  <div class="grid large--display-table">
+    <div class="grid-item large--one-fifth large--display-table-cell medium--one-third">
+      <a href="{{ product.url | within: current_collection }}" class="product-loop-image">
         <img src="{{ product.featured_image.src | img_url: 'medium' }}" alt="{{ product.featured_image.alt | escape }}" class="product-grid-image">
-      </div>
-      <div class="grid-item large--three-fifths large--display-table-cell medium--two-thirds">
-        <p class="h6">{{ product.title }}</p>
-        <div class="rte">
-          {% if product.excerpt.size > 0 %}
-            {{ product.excerpt }}
-          {% else %}
-            <p>{{ product.content | strip_html | truncatewords: 30 }}</p>
-          {% endif %}
-        </div>
-      </div>
-      <div class="grid-item large--one-fifth large--display-table-cell medium--two-thirds">
-        {% comment %}
-          You can show a leading 'from' or 'up to' by checking 'product.price_varies'
-          if your variants have different prices.
-        {% endcomment %}
-        {% if product.price_varies %}From{% endif %}
-        {{ product.price | money }}
-        {% if sold_out %}
-          <br><strong>Sold Out</strong>
-        {% endif %}
-        {% if on_sale %}
-          <br><strong>On Sale</strong> from {{ product.compare_at_price | money }}
+      </a>
+    </div>
+    <div class="grid-item large--three-fifths large--display-table-cell medium--two-thirds">
+      <p class="h6">
+         <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
+      </p>
+      <div class="rte">
+        {% if product.excerpt.size > 0 %}
+          {{ product.excerpt }}
+        {% else %}
+          <p>{{ product.content | strip_html | truncatewords: 30 }}</p>
         {% endif %}
       </div>
     </div>
-  </a>
+    <div class="grid-item large--one-fifth large--display-table-cell medium--two-thirds">
+      {% comment %}
+        You can show a leading 'from' or 'up to' by checking 'product.price_varies'
+        if your variants have different prices.
+      {% endcomment %}
+      {% if product.price_varies %}From{% endif %}
+      {{ product.price | money }}
+      {% if sold_out %}
+        <br><strong>Sold Out</strong>
+      {% endif %}
+      {% if on_sale %}
+        <br><strong>On Sale</strong> from {{ product.compare_at_price | money }}
+      {% endif %}
+    </div>
+  </div>
 </div>

--- a/snippets/product-list-item.liquid
+++ b/snippets/product-list-item.liquid
@@ -47,7 +47,7 @@
   <div class="grid large--display-table">
     <div class="grid-item large--one-fifth large--display-table-cell medium--one-third">
       <a href="{{ product.url | within: current_collection }}" class="product-loop-image">
-        <img src="{{ product.featured_image.src | img_url: 'medium' }}" alt="{{ product.featured_image.alt | escape }}" class="product-grid-image">
+        <img src="{{ product.featured_image.src | img_url: 'medium' }}" alt="{{ product.featured_image.alt | escape }}">
       </a>
     </div>
     <div class="grid-item large--three-fifths large--display-table-cell medium--two-thirds">


### PR DESCRIPTION
Attempting to create a little more consistency in behavior on collection grid and list views by refactoring product loop snippets : product-grid-item.liquid and product-list-item.liquid.

* currently collection list product loop items are mostly wrapped in anchor (including description)

* inconsistent use of class `a.product-grid-image` in product-grid-item.liquid vs  `img.product-grid-image` in product-list-item.liquid

* class `.product-grid-item` does not exist in the product-grid-item.liquid snippet but does in fact show in the product-list-item.liquid snippet -- this naming of elements can be confusing.

To address all of these, this PR contains the following:

* introduce classes `.product-grid-item` and `.product-list-item` in parent (`div.grid-item`) for snippets product-grid-item.liquid and product-list-item.liquid, respectively. remove use of these classes elsewhere; thus creating unique parent class for each view

* move anchor in `.product-list-item` to only wrap product image as it does in product-grid-item.liquid. Also add to product-list-item.liquid an anchor around product title, as it does in product-grid-item.liquid  (therefore consistent objects link to product pages from either collection view)

* introduce ambiguous class of `.product-loop-image` to product image anchors instead of `.product-grid-image` since grid has more specific context now.  thus, also remove `.product-grid-image` class references

* adjust theme.scss accordingly