### PR TITLE
add base .text-left

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -696,6 +696,7 @@ body {
 .right { float: right; }
 .text-center { text-align: center; }
 .text-right { text-align: right; }
+.text-left { text-align: left; }
 .hidden { display: none; }
 
 .display-table {


### PR DESCRIPTION
docs say we have `.text-left` base class, but upon further review... not sure we do.
