### PR TITLE
Remove error class from register name fields.

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -116,7 +116,11 @@
           {% if shop.customer_accounts_enabled %}
           <p class="site-header--text-links">
             {% if customer %}
-              {{ 'layout.customer.logged_in_as' | t }} <a href="/account">{{ customer.first_name }}</a>
+              {% if customer.first_name != blank %}
+                {{ 'layout.customer.logged_in_as' | t }} <a href="/account">{{ customer.first_name }}</a>
+              {% else %}
+                <a href="/account">{{ 'layout.customer.account' | t }}</a>
+              {% endif %}
               | {{ 'layout.customer.log_out' | t | customer_logout_link }}
             {% else %}
               {{ 'layout.customer.log_in' | t | customer_login_link }}

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -239,6 +239,7 @@
       }
     },
     "customer": {
+      "account": "Account",
       "logged_in_as": "Logged in as",
       "log_out": "Log out",
       "log_in": "Log in",

--- a/locales/fr-CA.json
+++ b/locales/fr-CA.json
@@ -239,6 +239,7 @@
       }
     },
     "customer": {
+      "account": "Compte",
       "logged_in_as": "Connecté en tant que",
       "log_out": "Se déconnecter",
       "log_in": "Se connecter",

--- a/templates/customers/register.liquid
+++ b/templates/customers/register.liquid
@@ -26,10 +26,10 @@
       {% include 'form-errors-custom' %}
 
       <label for="first_name" class="hidden-label">{{ 'customer.register.first_name' | t }}</label>
-      <input type="text" name="customer[first_name]" id="first_name" placeholder="{{ 'customer.register.first_name' | t }}" {% if form.errors contains "first_name" %} class="error"{% elsif form.first_name %} value="{{ form.first_name }}"{% endif %} autocapitalize="words" autofocus>
+      <input type="text" name="customer[first_name]" id="first_name" placeholder="{{ 'customer.register.first_name' | t }}" {% if form.first_name %}value="{{ form.first_name }}"{% endif %} autocapitalize="words" autofocus>
 
       <label for="last_name" class="hidden-label">{{ 'customer.register.last_name' | t }}</label>
-      <input type="text" name="customer[last_name]" id="last_name" placeholder="{{ 'customer.register.last_name' | t }}" {% if form.errors contains "last_name" %} class="error"{% elsif form.last_name %} value="{{ form.last_name }}"{% endif %} autocapitalize="words">
+      <input type="text" name="customer[last_name]" id="last_name" placeholder="{{ 'customer.register.last_name' | t }}" {% if form.last_name %}value="{{ form.last_name }}"{% endif %} autocapitalize="words">
 
       <label for="email" class="hidden-label">{{ 'customer.register.email' | t }}</label>
       <input type="email" name="customer[email]" id="email" placeholder="{{ 'customer.register.email' | t }}" {% if form.errors contains "email" %} class="error"{% elsif form.email %} value="{{ form.email }}"{% endif %} autocorrect="off" autocapitalize="off">


### PR DESCRIPTION
Fixes #213 
- Remove error classes on `first_name` and `last_name` fields on the registration page.
- Created a general `Account` link if no first name is set so users can still access their profile
