### PR TITLE
Noindex on pages using list view

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -30,6 +30,9 @@
   <!-- Helpers ================================================== -->
   <link rel="canonical" href="{{ canonical_url }}">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  {% if template contains 'list' %}
+  <meta name="robots" content="noindex">
+  {% endif %}
 
   <!-- CSS ================================================== -->
   {{ 'timber.scss.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
Google was indexing collections with the list view parameter and was hitting me with duplicate content.

The way I set up my sites is to not index collection pages that contains tags. I feel like that is more of a situational thing so I did not add it into the commit. 