### PR TITLE
Cleaned up collection sidebar

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -90,7 +90,6 @@
     },
     "sidebar": {
       "types": "Produktart",
-      "no_types_html": "Fügen Sie zum Aufbau dieser Liste eine Produktart hinzu. Alle Listen werden in <strong>collection-sidebar.liquid</strong> erstellt.",
       "vendors": "Verkäufer",
       "tags": "Tags"
     },

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -90,7 +90,6 @@
     },
     "sidebar": {
       "types": "Product Types",
-      "no_types_html": "Add a type to your products for this list to build itself. All lists are created in <strong>collection-sidebar.liquid</strong>.",
       "vendors": "Vendors",
       "tags": "Tags"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -92,7 +92,6 @@
     },
     "sidebar": {
       "types": "Tipos de producto",
-      "no_types_html": "Agregue un tipo a sus productos para que se genere esta lista. Todas las listas son creadas en <strong>collection-sidebar.liquid</strong>.",
       "vendors": "Proveedores",
       "tags": "Etiquetas"
     },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -90,7 +90,6 @@
     },
     "sidebar": {
       "types": "Types de produits",
-      "no_types_html": "Ajoutez un type à vos produits pour que cette liste soit automatiquement générée. Toutes les listes sont créées dans <strong>collection-sidebar.liquid</strong>.",
       "vendors": "Fournisseurs",
       "tags": "Filtres"
     },

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -90,7 +90,6 @@
     },
     "sidebar": {
       "types": "Tipos de Produtos",
-      "no_types_html": "Adicione tipos aos seus produtos para que esta lista seja construída automaticamente. Todas as listas são criadas na <strong>collection-sidebar.liquid</strong>.",
       "vendors": "Fornecedores",
       "tags": "Etiquetas"
     },

--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -29,8 +29,6 @@
       {% endif %}
     {% endfor %}
   </ul>
-{% else %}
-  <p>{{ 'collections.sidebar.no_types_html' | t }}</p>
 {% endif %}
 
 {% comment %}
@@ -38,70 +36,74 @@
     - List all of the shop's vendors with collections.all.all_vendors
     - List the current collection's vendors with collection.all_vendors
 {% endcomment %}
-<h3>{{ 'collections.sidebar.vendors' | t }}</h3>
-<ul>
-  {% for vendor in collection.all_vendors %}
-    {% if collection.current_vendor == vendor %}
-      <li class="filter--active">
-        {{ vendor }}
-      </li>
-    {% else %}
-      <li>
-        {{ vendor | link_to_vendor }}
-      </li>
-    {% endif %}
-  {% endfor %}
-</ul>
+{% if collection.all_vendors.size > 1 %}
+  <h3>{{ 'collections.sidebar.vendors' | t }}</h3>
+  <ul>
+    {% for vendor in collection.all_vendors %}
+      {% if collection.current_vendor == vendor %}
+        <li class="filter--active">
+          {{ vendor }}
+        </li>
+      {% else %}
+        <li>
+          {{ vendor | link_to_vendor }}
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endif %}
 
 {% comment %}
   Product tags in the current collection
 {% endcomment %}
-<h3>{{ 'collections.sidebar.tags' | t }}</h3>
-
-{% comment %}
-  To provide a 'catch-all' link at the top of the list,
-  check against the collection.handle, product type, and vendor.
-{% endcomment %}
-<ul>
-  <li{% unless current_tags %} class="filter--active"{% endunless %}>
-
-    {% comment %}
-      Good for /collections/all collection and regular collections
-    {% endcomment %}
-    {% if collection.handle %}
-      <a href="/collections/{{ collection.handle }}">All {{ collection.title }}</a>
-
-    {% comment %}
-      Good for automatic type collections
-    {% endcomment %}
-    {% elsif collection.current_type %}
-      <a href="{{ collection.current_type | url_for_type }}">All {{ collection.title }}</a>
-
-    {% comment %}
-      Good for automatic vendor collections
-    {% endcomment %}
-    {% elsif collection.current_vendor %}
-      <a href="{{ collection.current_vendor | url_for_vendor }}">All {{ collection.title }}</a>
-
-    {% endif %}
-  </li>
+{% if collection.all_tags.size > 0 %}
+  <h3>{{ 'collections.sidebar.tags' | t }}</h3>
 
   {% comment %}
-    And for the good stuff, loop through the tags themselves.
+    To provide a 'catch-all' link at the top of the list,
+    check against the collection.handle, product type, and vendor.
   {% endcomment %}
-  {% for tag in collection.all_tags %}
-    {% if current_tags contains tag %}
-      <li class="filter--active">
-        {{ tag | link_to_remove_tag: tag }}
-      </li>
-    {% else %}
-      <li>
-        {% comment %}
-          Use link_to_add_tag if you want to allow filtering
-          by multiple tags
-        {% endcomment %}
-        {{ tag | link_to_tag: tag }}
-      </li>
-    {% endif %}
-  {% endfor %}
-</ul>
+  <ul>
+    <li{% unless current_tags %} class="filter--active"{% endunless %}>
+
+      {% comment %}
+        Good for /collections/all collection and regular collections
+      {% endcomment %}
+      {% if collection.handle %}
+        <a href="/collections/{{ collection.handle }}">All {{ collection.title }}</a>
+
+      {% comment %}
+        Good for automatic type collections
+      {% endcomment %}
+      {% elsif collection.current_type %}
+        <a href="{{ collection.current_type | url_for_type }}">All {{ collection.title }}</a>
+
+      {% comment %}
+        Good for automatic vendor collections
+      {% endcomment %}
+      {% elsif collection.current_vendor %}
+        <a href="{{ collection.current_vendor | url_for_vendor }}">All {{ collection.title }}</a>
+
+      {% endif %}
+    </li>
+
+    {% comment %}
+      And for the good stuff, loop through the tags themselves.
+    {% endcomment %}
+    {% for tag in collection.all_tags %}
+      {% if current_tags contains tag %}
+        <li class="filter--active">
+          {{ tag | link_to_remove_tag: tag }}
+        </li>
+      {% else %}
+        <li>
+          {% comment %}
+            Use link_to_add_tag if you want to allow filtering
+            by multiple tags
+          {% endcomment %}
+          {{ tag | link_to_tag: tag }}
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endif %}


### PR DESCRIPTION
Only show types/vendors/tags if they exist. No empty state for these. For vendors, I've checked to see if there are more than one, seeing as there has to be at least one by default.

@fredryk You asked for this change a while back right? I believe I did it in another PR but it got lost and not merged.

cc @stevebosworth 
