### PR TITLE
Adding missing translations to 'Edit Address' section.

### DIFF
--- a/templates/customers/addresses.liquid
+++ b/templates/customers/addresses.liquid
@@ -150,13 +150,13 @@
             <label for="AddressAddress1_{{form.id}}">{{ 'customer.addresses.address1' | t }}</label>
             <input type="text" id="AddressAddress1_{{form.id}}" class="address_form" name="address[address1]" value="{{form.address1}}" autocapitalize="words">
 
-            <label for="AddressAddress2_{{form.id}}">Address 2</label>
+            <label for="AddressAddress2_{{form.id}}">{{ 'customer.addresses.address2' | t }}</label>
             <input type="text" id="AddressAddress2_{{form.id}}" class="address_form" name="address[address2]" value="{{form.address2}}" autocapitalize="words">
 
-            <label for="AddressCity_{{form.id}}">City</label>
+            <label for="AddressCity_{{form.id}}">{{ 'customer.addresses.city' | t }}</label>
             <input type="text" id="AddressCity_{{form.id}}" class="address_form" name="address[city]" value="{{form.city}}" autocapitalize="words">
 
-            <label for="AddressCountry_{{form.id}}">Country</label>
+            <label for="AddressCountry_{{form.id}}">{{ 'customer.addresses.country' | t }}</label>
             <select id="AddressCountry_{{form.id}}" name="address[country]" data-default="{{form.country}}">{{ country_option_tags }}</select>
 
             <div id="AddressProvinceContainer_{{form.id}}" style="display:none">


### PR DESCRIPTION
English labels were hard-coded, changed to translatable tags.
