### PR TITLE
Force select option text color for IE

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1358,9 +1358,10 @@ select {
   }
 }
 
-// Force option text color (affects IE only)
+// Force option color (affects IE only)
 option {
   color: #000;
+  background-color: #fff;
 }
 
 select::-ms-expand {


### PR DESCRIPTION
Small but necessary addition. IE10 dropdowns have a fixed white background color. This forces the text to always be visible, rather than inherit the select's text color. This is evident in dark themes that use white as the `select` text color. This only affects IE's `option` elements, as nearly every other browser has a preset style that you can't override.

Only downside is that IE9 will also change the current value's text color, so we need to force the background color too. IE9 screenshot is below. I think it's an acceptable flaw to this.

![screen shot 2014-11-19 at 8 53 46 am](https://cloud.githubusercontent.com/assets/1730309/5106785/d2f1236c-6fc9-11e4-98bb-ef6387190631.png)

cc/ @Shopify/fed
