### PR TITLE
Android theme color

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,7 +31,6 @@
   <link rel="canonical" href="{{ canonical_url }}">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="{{ settings.color_primary }}">
-  http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
 
   {% if settings.ajax_cart_enable %}
   <!-- Ajaxify Cart Plugin ================================================== -->


### PR DESCRIPTION
As per [this article](http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android), you can set the Android tab color for your site with a simple meta tag. Nothing like a hint more personality on the mobile web.

![theme-color-ss-9950fd13a0c52b32b6bd580309d55a6b](https://cloud.githubusercontent.com/assets/1730309/5206692/b7cc7ebc-7571-11e4-8f32-1e9e12c56469.png)

cc @Shopify/fed 
