### PR TITLE
Minor syntax fix. Placeholder ie label fix

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -784,7 +784,7 @@ var ajaxifyShopify = (function(module, $) {
     // Handlebars.js cart layout
     var items = [],
         item = {},
-        data = {}
+        data = {},
         source = $("#CartTemplate").html(),
         template = Handlebars.compile(source);
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1388,6 +1388,7 @@ legend {
     .ie9 &,
     .lt-ie9 & {
       height: auto;
+      width: auto;
       margin-bottom: 2px;
       overflow: visible;
     }


### PR DESCRIPTION
Fixes #282 and fallback label widths when `placeholder` is not supported.
