### PR TITLE
I18n ajaxify

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -445,7 +445,7 @@ var ajaxifyShopify = (function(module, $) {
     $modalOverlay.on('click', hideModal);
 
     // Create a close modal button
-    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="Close Cart">Close Cart</button>');
+    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t }}">{{ 'cart.general.close_cart' | t }}</button>');
     $closeCart = $('.ajaxcart__close');
     $closeCart.on('click', hideModal);
 

--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -394,9 +394,9 @@ var ajaxifyShopify = (function(module, $) {
     $addToCart.addClass('flip__front').wrap('<div class="flip"></div>');
 
     // Write a (hidden) Checkout button, a loader, and the extra view cart button
-    var checkoutBtn = $('<a href="/cart" class="flip__back" style="background-color: #C00; color: #fff;" class="flip__checkout">Checkout</a>').addClass($btnClass),
+    var checkoutBtn = $('<a href="/cart" class="flip__back" style="background-color: #C00; color: #fff;" class="flip__checkout">{{ 'cart.general.checkout' | t }} </a>').addClass($btnClass),
         flipLoader = $('<span class="ajaxcart__flip-loader"></span>'),
-        flipExtra = $('<div class="flip__extra"><a href="#" class="flip__cart">View Cart (<span></span>)</a></div>');
+        flipExtra = $('<div class="flip__extra"><a href="#" class="flip__cart">{{ 'cart.general.view_cart' | t }} (<span></span>)</a></div>');
 
     // Append checkout button and loader
     checkoutBtn.insertAfter($addToCart);

--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -870,7 +870,7 @@ var ajaxifyShopify = (function(module, $) {
             sizeDrawer(true);
           }
           // Create a close drawer button
-          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="Close Cart">Close Cart</button>');
+          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t }} ">{{ 'cart.general.close_cart' | t }} </button>');
           $closeCart = $('.ajaxcart__close');
           $closeCart.on('click', hideDrawer);
           break;

--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -394,9 +394,9 @@ var ajaxifyShopify = (function(module, $) {
     $addToCart.addClass('flip__front').wrap('<div class="flip"></div>');
 
     // Write a (hidden) Checkout button, a loader, and the extra view cart button
-    var checkoutBtn = $('<a href="/cart" class="flip__back" style="background-color: #C00; color: #fff;" class="flip__checkout">{{ 'cart.general.checkout' | t }} </a>').addClass($btnClass),
+    var checkoutBtn = $('<a href="/cart" class="flip__back" style="background-color: #C00; color: #fff;" class="flip__checkout">{{ 'cart.general.checkout' | t | json }} </a>').addClass($btnClass),
         flipLoader = $('<span class="ajaxcart__flip-loader"></span>'),
-        flipExtra = $('<div class="flip__extra"><a href="#" class="flip__cart">{{ 'cart.general.view_cart' | t }} (<span></span>)</a></div>');
+        flipExtra = $('<div class="flip__extra"><a href="#" class="flip__cart">{{ 'cart.general.view_cart' | t | json }} (<span></span>)</a></div>');
 
     // Append checkout button and loader
     checkoutBtn.insertAfter($addToCart);
@@ -445,7 +445,7 @@ var ajaxifyShopify = (function(module, $) {
     $modalOverlay.on('click', hideModal);
 
     // Create a close modal button
-    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t }}">{{ 'cart.general.close_cart' | t }}</button>');
+    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t | json }}">{{ 'cart.general.close_cart' | t | json }}</button>');
     $closeCart = $('.ajaxcart__close');
     $closeCart.on('click', hideModal);
 
@@ -870,7 +870,7 @@ var ajaxifyShopify = (function(module, $) {
             sizeDrawer(true);
           }
           // Create a close drawer button
-          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t }} ">{{ 'cart.general.close_cart' | t }} </button>');
+          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t | json }} ">{{ 'cart.general.close_cart' | t | json }} </button>');
           $closeCart = $('.ajaxcart__close');
           $closeCart.on('click', hideDrawer);
           break;

--- a/locales/de.json
+++ b/locales/de.json
@@ -62,7 +62,7 @@
       "update": "Einkaufswagen aktualisieren",
       "checkout": "Zur Kasse",
       "empty": "Ihr Einkaufswagen ist im Moment leer.",
-      "continue_browsing_html": "Mit der Suche <a href=\"/collections/all\">hier</a> fortfahren."
+      "continue_browsing_html": "Mit der Suche <a href=\"/collections/all\">hier</a> fortfahren.",
       "view_cart": "View.Cart.de",
       "close_cart": "Close.Cart.de"
     },

--- a/locales/de.json
+++ b/locales/de.json
@@ -63,6 +63,8 @@
       "checkout": "Zur Kasse",
       "empty": "Ihr Einkaufswagen ist im Moment leer.",
       "continue_browsing_html": "Mit der Suche <a href=\"/collections/all\">hier</a> fortfahren."
+      "view_cart": "View.Cart.de",
+      "close_cart": "Close.Cart.de"
     },
     "label": {
       "product": "Artikel",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -63,6 +63,8 @@
       "checkout": "Check Out",
       "empty": "Your cart is currently empty.",
       "continue_browsing_html": "Continue browsing <a href=\"/collections/all\">here</a>."
+      "view_cart": "View Cart",
+      "close_cart": "Close Cart"
     },
     "label": {
       "product": "Product",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -62,7 +62,7 @@
       "update": "Update Cart",
       "checkout": "Check Out",
       "empty": "Your cart is currently empty.",
-      "continue_browsing_html": "Continue browsing <a href=\"/collections/all\">here</a>."
+      "continue_browsing_html": "Continue browsing <a href=\"/collections/all\">here</a>.",
       "view_cart": "View Cart",
       "close_cart": "Close Cart"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -62,7 +62,7 @@
       "update": "Actualizar carrito",
       "checkout": "Finalizar pedido",
       "empty": "Su carrito actualmente está vacío.",
-      "continue_browsing_html": "Continúe explorando <a href=\"/collections/all\">aquí</a>."
+      "continue_browsing_html": "Continúe explorando <a href=\"/collections/all\">aquí</a>.",
       "view_cart": "View.Cart.es",
       "close_cart": "Close.Cart.es"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -63,6 +63,8 @@
       "checkout": "Finalizar pedido",
       "empty": "Su carrito actualmente está vacío.",
       "continue_browsing_html": "Continúe explorando <a href=\"/collections/all\">aquí</a>."
+      "view_cart": "View.Cart.es",
+      "close_cart": "Close.Cart.es"
     },
     "label": {
       "product": "Producto",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -63,6 +63,8 @@
       "checkout": "Procéder au paiement",
       "empty": "Votre panier est vide.",
       "continue_browsing_html": "<a href=\"/collections/all\">Retourner au magasinage</a>."
+      "view_cart": "View.Cart.fr",
+      "close_cart": "Close.Cart.fr"
     },
     "label": {
       "product": "Produit",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -62,7 +62,7 @@
       "update": "Mettre à jour",
       "checkout": "Procéder au paiement",
       "empty": "Votre panier est vide.",
-      "continue_browsing_html": "<a href=\"/collections/all\">Retourner au magasinage</a>."
+      "continue_browsing_html": "<a href=\"/collections/all\">Retourner au magasinage</a>.",
       "view_cart": "View.Cart.fr",
       "close_cart": "Close.Cart.fr"
     },

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -62,7 +62,7 @@
       "update": "Atualizar Carrinho",
       "checkout": "Fechar pedido",
       "empty": "Seu carrinho está vazio no momento.",
-      "continue_browsing_html": "Continue navegando <a href=\"/collections/all\">aqui</a>."
+      "continue_browsing_html": "Continue navegando <a href=\"/collections/all\">aqui</a>.",
       "view_cart": "View.Cart.pt.BR",
       "close_cart": "Close.Cart.pt.BR"
     },

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -63,6 +63,8 @@
       "checkout": "Fechar pedido",
       "empty": "Seu carrinho está vazio no momento.",
       "continue_browsing_html": "Continue navegando <a href=\"/collections/all\">aqui</a>."
+      "view_cart": "View.Cart.pt.BR",
+      "close_cart": "Close.Cart.pt.BR"
     },
     "label": {
       "product": "Produto",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -62,7 +62,7 @@
       "update": "Atualizar Carrinho de Compras",
       "checkout": "Check-Out",
       "empty": "O seu carrinho de compras está neste momento vazio.",
-      "continue_browsing_html": "Continue a ver <a href=\"/collections/all\">aqui</a>."
+      "continue_browsing_html": "Continue a ver <a href=\"/collections/all\">aqui</a>.",
       "view_cart": "View.Cart.pt.PT",
       "close_cart": "Close.Cart.pt.PT"
     },

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -63,6 +63,8 @@
       "checkout": "Check-Out",
       "empty": "O seu carrinho de compras está neste momento vazio.",
       "continue_browsing_html": "Continue a ver <a href=\"/collections/all\">aqui</a>."
+      "view_cart": "View.Cart.pt.PT",
+      "close_cart": "Close.Cart.pt.PT"
     },
     "label": {
       "product": "Produto",


### PR DESCRIPTION
The ajaxify.js has some hard-codded English texts that I replaced with i18n keys.
Since two of the texts does not exist in the locale files, I have added them in the default.
Also in other out-of-box locales, I used the following format: (e.g. Spanish translation of "Close Cart")
close_cart : close_cart_es

I have tested them manually and it works fine. I am not sure if I need to write test for i18n fixes or not.
Ping @cshold 
