### PR TITLE
Ajaxify image

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -801,10 +801,12 @@ var ajaxifyShopify = (function(module, $) {
        *   - A hard-coded url of no-image
       */
   
-      if (cartItem.image != null)
+      if (cartItem.image != null){
         var prodImg = cartItem.image.replace(/(\.[^.]*)$/, "_small$1").replace('http:', '');
-      else 
+      }
+      else {
         var prodImg = "http://cdn.shopify.com/s/assets/admin/no-image-medium-cc9732cb976dd349a0df1d39816fbcc7.gif";
+      }
   
       var prodName = cartItem.title.replace(/(\-[^-]*)$/, ""),
           prodVariation = cartItem.title.replace(/^[^\-]*/, "").replace(/-/, "");


### PR DESCRIPTION
_Issue_: There is an issue in the [ajaxify.js](https://github.com/Shopify/Timber/blob/master/assets/ajaxify.js.liquid), when the default cart is used (useCartTemplate = false).
If the product that is added to the cart has no image, the ajaxify shopping cart doesn't open.

_Reason_: There is a [hack](https://github.com/Shopify/Timber/blob/master/assets/ajaxify.js.liquid#L797-804) in this code that create the thumbnail of the image by adding "_small" at the end of the file name. However, /cart.js will return null for products with no image.

_Good Solution_: Change the Shopify API to return the "no-image" thumbnail instead of null when there is no image assigned to the product

_Hack Solution_: hard-coding the url of the default no-image thumbnail. I just used [the one](http://cdn.shopify.com/s/assets/admin/no-image-medium-cc9732cb976dd349a0df1d39816fbcc7.gif) that I got from my shop. It doesn't look to be the generic one, and also it is medium according to the url. 
