### PR TITLE
Fixed how strings are appended in ajax cart

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -445,7 +445,7 @@ var ajaxifyShopify = (function(module, $) {
     $modalOverlay.on('click', hideModal);
 
     // Create a close modal button
-    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t | json }}">{{ 'cart.general.close_cart' | t | json }}</button>');
+    $modalContainer.prepend('<button type="button" class="ajaxcart__close" title="' + {{ 'cart.general.close_cart' | t | json }} + '">' + {{ 'cart.general.close_cart' | t | json }} + '</button>');
     $closeCart = $('.ajaxcart__close');
     $closeCart.on('click', hideModal);
 
@@ -878,7 +878,7 @@ var ajaxifyShopify = (function(module, $) {
             sizeDrawer(true);
           }
           // Create a close drawer button
-          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="{{ 'cart.general.close_cart' | t | json }} ">{{ 'cart.general.close_cart' | t | json }} </button>');
+          $cartContainer.prepend('<button type="button" class="ajaxcart__close" title="' + {{ 'cart.general.close_cart' | t | json }} + '">' + {{ 'cart.general.close_cart' | t | json }} + '</button>');
           $closeCart = $('.ajaxcart__close');
           $closeCart.on('click', hideDrawer);
           break;


### PR DESCRIPTION
Strings were being brought in with double quotes, breaking the `title` attribute and including double quotes around the string. This fixes it.

cc/ @stevebosworth 