### PR TITLE
Fixed broken replaceUrlParam function

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -1,8 +1,10 @@
 // Helper functions
 function replaceUrlParam(url, paramName, paramValue) {
   var pattern = new RegExp('('+paramName+'=).*?(&|$)'),
-      newUrl = url.replace(pattern,'$1' + paramValue + '$2');
-  if ( newUrl == url ) {
+      newUrl = url;
+  if (url.search(pattern) >= 0) {
+    newUrl = url.replace(pattern,'$1' + paramValue + '$2');
+  } else {
     newUrl = newUrl + (newUrl.indexOf('?')>0 ? '&' : '?') + paramName + '=' + paramValue;
   }
   return newUrl;


### PR DESCRIPTION
Fixes #312 to make sure duplicate parameters don't get added to the URL.

Via second answer [here](http://stackoverflow.com/questions/7171099/how-to-replace-url-parameter-with-javascript-jquery).

[Demo here](https://carson-dev-shop.myshopify.com/collections/all?view=grid)

cc/ @stevebosworth @Woland2k