### PR TITLE
Make all headers blocks

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -733,6 +733,7 @@ select {
 }
 
 h1, h2, h3, h4, h5, h6 {
+  display: block;
   font-family: $headerFontStack;
   font-weight: $headerFontWeight;
   margin: 0 0 0.5em;


### PR DESCRIPTION
Fixes #314

As shown in [this example](http://timber-test-3.myshopify.com/products/die-cast-cars-with-case-8985?variant=1098771568), the "Sold Out" looks to be floated beside the price. Turns out that all instances of elements that extend our headers by using a class (in this case `<span class="h2">`) don't get set as block, but inherit their element's layout.

The issues only occurs when the CTA on the product page immediately follows the price. The quantity selector between them hides the problem.

This forces all extended headers to be blocks. Can test at https://carson-dev-shop.myshopify.com/

cc/ @spuddick @stevebosworth @mpiotrowicz 