### PR TITLE
Update cart properties size check

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -989,7 +989,7 @@ hr {
   }
 }
 
-.rte-header {
+.rte--header {
   margin-bottom: 0;
 }
 

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -80,24 +80,22 @@
                   For more info on line item properties, visit:
                     - http://docs.shopify.com/support/your-store/products/how-do-I-collect-additional-information-on-the-product-page-Like-for-a-monogram-engraving-or-customization
                 {% endcomment %}
-                {% if item.properties.size > 0 %}
-                  {% for p in item.properties %}
-                    {% unless p.last == blank %}
-                      {{ p.first }}:
+                {% for p in item.properties %}
+                  {% unless p.last == blank %}
+                    {{ p.first }}:
 
-                      {% comment %}
-                        Check if there was an uploaded file associated
-                      {% endcomment %}
-                      {% if p.last contains '/uploads/' %}
-                        <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
-                      {% else %}
-                        {{ p.last }}
-                      {% endif %}
+                    {% comment %}
+                      Check if there was an uploaded file associated
+                    {% endcomment %}
+                    {% if p.last contains '/uploads/' %}
+                      <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
+                    {% else %}
+                      {{ p.last }}
+                    {% endif %}
 
-                      <br>
-                    {% endunless %}
-                  {% endfor %}
-                {% endif %}
+                    <br>
+                  {% endunless %}
+                {% endfor %}
 
                 <a href="/cart/change?line={{ forloop.index }}&amp;quantity=0" class="cart__remove" data-id="{{ item.id }}">
                   <small>{{ 'cart.general.remove' | t }}</small>

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -80,22 +80,25 @@
                   For more info on line item properties, visit:
                     - http://docs.shopify.com/support/your-store/products/how-do-I-collect-additional-information-on-the-product-page-Like-for-a-monogram-engraving-or-customization
                 {% endcomment %}
-                {% for p in item.properties %}
-                  {% unless p.last == blank %}
-                    {{ p.first }}:
+                {% assign propertySize = item.properties | size %}
+                {% if propertySize > 0 %}
+                  {% for p in item.properties %}
+                    {% unless p.last == blank %}
+                      {{ p.first }}:
 
-                    {% comment %}
-                      Check if there was an uploaded file associated
-                    {% endcomment %}
-                    {% if p.last contains '/uploads/' %}
-                      <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
-                    {% else %}
-                      {{ p.last }}
-                    {% endif %}
+                      {% comment %}
+                        Check if there was an uploaded file associated
+                      {% endcomment %}
+                      {% if p.last contains '/uploads/' %}
+                        <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
+                      {% else %}
+                        {{ p.last }}
+                      {% endif %}
 
-                    <br>
-                  {% endunless %}
-                {% endfor %}
+                      <br>
+                    {% endunless %}
+                  {% endfor %}
+                {% endif %}
 
                 <a href="/cart/change?line={{ forloop.index }}&amp;quantity=0" class="cart__remove" data-id="{{ item.id }}">
                   <small>{{ 'cart.general.remove' | t }}</small>


### PR DESCRIPTION
As per [this Shopify forum post](https://ecommerce.shopify.com/c/partners-technical/t/timber-theme-bug-227059), `{% if item.properties.size > 0 %}` will never run so here it is removed. The `for` loop is more than capable of handling this on its own.

Fixes #317

cc @stevebosworth 