### PR TITLE
Protocol-relative image URLS

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -804,7 +804,7 @@ var ajaxifyShopify = (function(module, $) {
       if (cartItem.image != null){
         var prodImg = cartItem.image.replace(/(\.[^.]*)$/, "_small$1").replace('http:', '');
       } else {
-        var prodImg = "http://cdn.shopify.com/s/assets/admin/no-image-medium-cc9732cb976dd349a0df1d39816fbcc7.gif";
+        var prodImg = "//cdn.shopify.com/s/assets/admin/no-image-medium-cc9732cb976dd349a0df1d39816fbcc7.gif";
       }
 
       var prodName = cartItem.title.replace(/(\-[^-]*)$/, ""),

--- a/snippets/onboarding-empty-collection.liquid
+++ b/snippets/onboarding-empty-collection.liquid
@@ -19,7 +19,7 @@
         {% endcase %}
         <div class="grid__item one-half large--one-quarter">
           <a href="/admin/products" class="grid__image">
-            {% capture imageUrl %}http://cdn.shopify.com/s/images/themes/product-{{ index }}.png{% endcapture %}
+            {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ index }}.png{% endcapture %}
             {{ imageUrl | img_tag }}
           </a>
           <p class="h6"><a href="/admin/products">{{ 'home_page.onboarding.product_title' | t }}</a></p>

--- a/snippets/onboarding-featured-collections.liquid
+++ b/snippets/onboarding-featured-collections.liquid
@@ -12,7 +12,7 @@
       {% for i in (1..5) %}
         <div class="grid__item large--one-fifth medium--one-half">
           <a href="#" class="grid__image">
-            {% capture imageUrl %}http://cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
+            {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
             {{ imageUrl | img_tag }}
           </a>
           <p>

--- a/snippets/onboarding-featured-products.liquid
+++ b/snippets/onboarding-featured-products.liquid
@@ -12,7 +12,7 @@
       {% for i in (1..4) %}
         <div class="grid__item one-half large--one-quarter">
           <a href="/admin/products" class="grid__image">
-            {% capture imageUrl %}http://cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
+            {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
             {{ imageUrl | img_tag }}
           </a>
           <p class="h6"><a href="/admin/products">{{ 'home_page.onboarding.product_title' | t }}</a></p>


### PR DESCRIPTION
Global onboarding images have `http:` hardcoded in there. This PR removes that to make them relative. I'll update our public themes too if this gets the green light.

@stevebosworth @mpiotrowicz 