### PR TITLE
New drawers

### DIFF
--- a/assets/ajaxify.js.liquid
+++ b/assets/ajaxify.js.liquid
@@ -254,10 +254,10 @@ var ajaxifyShopify = (function(module, $) {
   var settings, cartInit, $drawerHeight, $cssTransforms, $cssTransforms3d, $nojQueryLoad, $w, $body, $html;
 
   // Private plugin variables
-  var $formContainer, $btnClass, $wrapperClass, $addToCart, $flipClose, $flipCart, $flipContainer, $cartCountSelector, $cartCostSelector, $toggleCartButton, $modal, $cartContainer, $drawerCaret, $modalContainer, $modalOverlay, $closeCart, $drawerContainer, $prependDrawerTo, $callbackData={};
+  var $formContainer, $btnClass, $wrapperClass, $addToCart, $flipClose, $flipCart, $flipContainer, $cartCountSelector, $cartCostSelector, $modal, $cartContainer, $modalContainer, $modalOverlay, $closeCart, $drawerContainer, $prependDrawerTo, $callbackData={};
 
   // Private functions
-  var updateCountPrice, flipSetup, revertFlipButton, modalSetup, showModal, sizeModal, hideModal, drawerSetup, showDrawer, hideDrawer, sizeDrawer, loadCartImages, formOverride, itemAddedCallback, itemErrorCallback, cartUpdateCallback, setToggleButtons, flipCartUpdateCallback, buildCart, cartTemplate, adjustCart, adjustCartCallback, createQtySelectors, qtySelectors, validateQty, scrollTop, toggleCallback;
+  var updateCountPrice, flipSetup, revertFlipButton, modalSetup, showModal, sizeModal, hideModal, drawerSetup, showDrawer, hideDrawer, sizeDrawer, loadCartImages, formOverride, itemAddedCallback, itemErrorCallback, cartUpdateCallback, flipCartUpdateCallback, buildCart, cartTemplate, adjustCart, adjustCartCallback, createQtySelectors, qtySelectors, validateQty, scrollTop, toggleCallback;
 
   /*============================================================================
     Initialise the plugin and define global options
@@ -271,7 +271,6 @@ var ajaxifyShopify = (function(module, $) {
       addToCartSelector: 'input[type="submit"]',
       cartCountSelector: null,
       cartCostSelector: null,
-      toggleCartButton: null,
       btnClass: null,
       wrapperClass: null,
       useCartTemplate: true,
@@ -302,7 +301,6 @@ var ajaxifyShopify = (function(module, $) {
     $flipClose         = null;
     $cartCountSelector = $(settings.cartCountSelector);
     $cartCostSelector  = $(settings.cartCostSelector);
-    $toggleCartButton  = $(settings.toggleCartButton);
     $modal             = null;
     $prependDrawerTo   = $(settings.prependDrawerTo);
 
@@ -467,9 +465,6 @@ var ajaxifyShopify = (function(module, $) {
         }
       }
     });
-
-    // Toggle modal with cart button
-    setToggleButtons();
   };
 
   showModal = function (toggle) {
@@ -537,37 +532,17 @@ var ajaxifyShopify = (function(module, $) {
     // Drawer selectors
     $drawerContainer = $('#AjaxifyDrawer');
     $cartContainer   = $('#AjaxifyCart');
-    $drawerCaret     = $('.ajaxcart__caret > span');
 
-    // Toggle drawer with cart button
-    setToggleButtons();
-
-    // Position caret and size drawer on resize if drawer is visible
+    // Size drawer on resize if drawer is visible
     var timeout;
     $(window).resize(function() {
       clearTimeout(timeout);
       timeout = setTimeout(function(){
         if ($drawerContainer.hasClass('is-visible')) {
-          positionCaret();
           sizeDrawer();
         }
       }, 500);
     });
-
-    // Position the caret the first time
-    positionCaret();
-
-    // Position the caret
-    function positionCaret() {
-      if ($toggleCartButton.offset()) {
-        // Get the position of the toggle button to align the caret with
-        var togglePos = $toggleCartButton.offset(),
-            toggleWidth = $toggleCartButton.outerWidth(),
-            toggleMiddle = togglePos.left + toggleWidth/2;
-
-        $drawerCaret.css('left', toggleMiddle + 'px');
-      }
-    }
   };
 
   showDrawer = function (toggle) {
@@ -705,41 +680,6 @@ var ajaxifyShopify = (function(module, $) {
           scrollTop();
         }
         break;
-    }
-  };
-
-  setToggleButtons = function () {
-    // Reselect the element in case it just loaded
-    $toggleCartButton  = $(settings.toggleCartButton);
-
-    if ($toggleCartButton) {
-      // Turn it off by default, in case it's initialized twice
-      $toggleCartButton.off('click');
-
-      // Toggle the cart, based on the method
-      $toggleCartButton.on('click', function(e) {
-        e.preventDefault();
-
-        switch (settings.method) {
-          case 'modal':
-            if ($modalContainer.hasClass('is-visible')) {
-              hideModal();
-            } else {
-              showModal(true);
-            }
-            break;
-          case 'drawer':
-          case 'flip':
-            if ($drawerContainer.hasClass('is-visible')) {
-              hideDrawer();
-            } else {
-              showDrawer(true);
-            }
-            break;
-        }
-
-      });
-
     }
   };
 

--- a/assets/ajaxify.scss.liquid
+++ b/assets/ajaxify.scss.liquid
@@ -612,42 +612,6 @@ form[action^="/cart/add"] {
   }
 }
 
-.ajaxcart__caret {
-  position: relative;
-  display: block;
-  height: 0;
-  opacity: 0;
-  overflow: hidden;
-
-  .is-visible + & {
-    opacity: 1;
-    overflow: visible;
-  }
-
-  & > span {
-    position: absolute;
-    top: 0;
-    left: 100%;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-top: 6px solid $colorBody;
-    margin-left: -6px;
-    opacity: 0;
-    @include transform(translate(0,-12px));
-    @include transition(all 0.25s ease-in-out 0.2s);
-  }
-
-  .is-visible + & > span {
-    @include transform(translate(0,0));
-    opacity: 1;
-  }
-}
-
-
-
 /*============================================================================
   Sprites
 //   - using data URIs to prevent any additional http requests

--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -1,14 +1,8 @@
-// Helper functions
-function replaceUrlParam(url, paramName, paramValue) {
-  var pattern = new RegExp('('+paramName+'=).*?(&|$)'),
-      newUrl = url;
-  if (url.search(pattern) >= 0) {
-    newUrl = url.replace(pattern,'$1' + paramValue + '$2');
-  } else {
-    newUrl = newUrl + (newUrl.indexOf('?')>0 ? '&' : '?') + paramName + '=' + paramValue;
-  }
-  return newUrl;
-}
+/* Jonathan Snook - MIT License - https://github.com/snookca/prepareTransition */
+(function(a){a.fn.prepareTransition=function(){return this.each(function(){var b=a(this);b.one("TransitionEnd webkitTransitionEnd transitionend oTransitionEnd",function(){b.removeClass("is-transitioning")});var c=["transition-duration","-moz-transition-duration","-webkit-transition-duration","-o-transition-duration"];var d=0;a.each(c,function(a,c){d=parseFloat(b.css(c))||d});if(d!=0){b.addClass("is-transitioning");b[0].offsetWidth}})}})(jQuery);
+
+/* replaceUrlParam - http://stackoverflow.com/questions/7171099/how-to-replace-url-parameter-with-javascript-jquery */
+function replaceUrlParam(e,r,a){var n=new RegExp("("+r+"=).*?(&|$)"),c=e;return c=e.search(n)>=0?e.replace(n,"$1"+a+"$2"):c+(c.indexOf("?")>0?"&":"?")+r+"="+a};
 
 // Timber functions
 window.timber = window.timber || {};
@@ -35,12 +29,13 @@ timber.cacheSelectors = function () {
     $recoverPasswordForm     : $('#RecoverPasswordForm'),
     $customerLoginForm       : $('#CustomerLoginForm'),
     $passwordResetSuccess    : $('#ResetSuccess')
-  }
+  };
 };
 
 timber.init = function () {
   timber.cacheSelectors();
   timber.accessibleNav();
+  timber.drawersInit();
   timber.productImageSwitch();
   timber.responsiveVideos();
   timber.collectionViews();
@@ -124,6 +119,11 @@ timber.accessibleNav = function () {
   function removeFocus ($el) {
     $el.removeClass(focusClass);
   }
+};
+
+timber.drawersInit = function () {
+  new timber.Drawers('NavDrawer', 'left');
+  new timber.Drawers('CartDrawer', 'right');
 };
 
 timber.getHash = function () {
@@ -262,6 +262,99 @@ timber.loginForms = function() {
 timber.resetPasswordSuccess = function() {
   timber.cache.$passwordResetSuccess.show();
 };
+
+// Timber Reusable Modules
+timber.Drawers = (function () {
+  var Drawer = function (id, position, options) {
+    var defaults = {
+      close: '.js-drawer-close',
+      open: '.js-drawer-open-' + position,
+      openClass: 'js-drawer-open',
+      dirOpenClass: 'js-drawer-open-' + position
+    };
+
+    this.$nodes = {
+      parent: $('body, html'),
+      page: $('#PageContainer'),
+      moved: $('.is-moved-by-drawer')
+    };
+
+    this.config = $.extend(defaults, options);
+    this.position = position;
+
+    this.$drawer = $('#' + id);
+
+    if (!this.$drawer.length) {
+      return false;
+    }
+
+    this.drawerIsOpen = false;
+    this.init();
+  };
+
+  Drawer.prototype.init = function () {
+    $(this.config.open).on('click', $.proxy(this.open, this));
+    this.$drawer.find(this.config.close).on('click', $.proxy(this.close, this));
+  };
+
+  Drawer.prototype.open = function (evt) {
+    evt.preventDefault();
+    // Without this, the drawer opens, the click event bubbles up to $nodes.page
+    // which closes the drawer.
+    if (evt && evt.stopPropagation) {
+      evt.stopPropagation();
+      // save the source of the click, we'll focus to this on close
+      this.$activeSource = $(evt.currentTarget);
+    }
+
+    if (this.drawerIsOpen) {
+      return this.close();
+    }
+
+    // Add is-transitioning class to moved elements on open so drawer can have
+    // transition for close animation
+    this.$nodes.moved.addClass('is-transitioning');
+    this.$drawer.prepareTransition();
+
+    this.$nodes.parent.addClass(this.config.openClass + ' ' + this.config.dirOpenClass);
+    this.drawerIsOpen = true;
+
+    if (this.$activeSource && this.$activeSource.attr('aria-expanded')) {
+      this.$activeSource.attr('aria-expanded', 'true');
+    }
+
+    // Lock scrolling on mobile
+    this.$nodes.page.on('touchmove.drawer', function () {
+      return false;
+    });
+
+    this.$nodes.page.on('click.drawer', $.proxy(function () {
+      this.close();
+      return false;
+    }, this));
+  };
+
+  Drawer.prototype.close = function () {
+    if (!this.drawerIsOpen) { // don't close a closed drawer
+      return;
+    }
+
+    // deselect any focused form elements
+    $(document.activeElement).trigger('blur');
+
+    // Ensure closing transition is applied to moved elements, like the nav
+    this.$nodes.moved.prepareTransition({ disableExisting: true });
+    this.$drawer.prepareTransition({ disableExisting: true });
+
+    this.$nodes.parent.removeClass(this.config.dirOpenClass + ' ' + this.config.openClass);
+
+    this.drawerIsOpen = false;
+
+    this.$nodes.page.off('.drawer');
+  };
+
+  return Drawer;
+})();
 
 // Initialize Timber's JS on docready
 $(timber.init);

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -35,6 +35,7 @@
   #Pagination
   #Site Header
   #Site Nav and Dropdowns
+  #Drawers
   #Site Footer
   #Product and Collection Grids
   #Collection Filters
@@ -72,6 +73,10 @@ $breakpoint-has-pull:  ('medium', 'medium-down', 'large');
 /*============================================================================
   #General Variables
 ==============================================================================*/
+
+// Drawer sizes
+$drawerNavWidth: 300px;
+$drawerCartWidth: 450px;
 
 // Timber Colors
 $colorPrimary: {{ settings.color_primary }};
@@ -173,6 +178,10 @@ $socialIconFontStack: 'icons';
 
 @mixin transition($transition: 0.1s all) {
   @include prefix('transition', #{$transition});
+}
+
+@mixin transform($transform: 0.1s all) {
+  @include prefix('transform', #{$transform});
 }
 
 @mixin gradient($from, $to, $fallback) {
@@ -689,6 +698,11 @@ body {
 /*============================================================================
   #Helper Classes
 ==============================================================================*/
+.is-transitioning {
+  display: block !important;
+  visibility: visible !important;
+}
+
 .display-table {
   display: table;
   table-layout: fixed;
@@ -1227,6 +1241,16 @@ textarea,
 button,
 select {
   font-size: 1em;
+  padding: 0;
+  margin: 0;
+  @include prefix('user-select', 'text');
+}
+
+button {
+  background: none;
+  border: none;
+  display: inline-block;
+  cursor: pointer;
 }
 
 button,
@@ -1884,6 +1908,75 @@ label.error {
   }
 }
 
+/*============================================================================
+  #Drawers
+==============================================================================*/
+.drawer {
+  display: none;
+  position: fixed;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  top: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: $colorNav;
+  @include transition('all 0.4s cubic-bezier(0.66, 0 , 0.41, 1)');
+}
+
+.drawer--left {
+  width: $drawerNavWidth;
+  left: -$drawerNavWidth;
+
+  .js-drawer-open-left & {
+    display: block;
+    @include transform(translateX($drawerNavWidth));
+
+    .lt-ie9 & {
+      left: 0;
+    }
+  }
+}
+
+.drawer--right {
+  width: $drawerCartWidth;
+  right: -$drawerCartWidth;
+
+  .js-drawer-open-right & {
+    display: block;
+    @include transform(translateX(-$drawerCartWidth));
+
+    .lt-ie9 & {
+      right: 0;
+    }
+  }
+}
+
+#PageContainer {
+  overflow: hidden;
+}
+
+.is-moved-by-drawer {
+  .js-drawer-open-left & {
+    @include transform(translateX($drawerNavWidth));
+    @include transition('all 0.4s cubic-bezier(0.66, 0 , 0.41, 1)');
+  }
+
+  .js-drawer-open-right & {
+    @include transform(translateX(-$drawerCartWidth));
+    @include transition('all 0.4s cubic-bezier(0.66, 0 , 0.41, 1)');
+  }
+}
+
+.is-moved-by-drawer.is-transitioning {
+  @include transition('all 0.4s cubic-bezier(0.66, 0 , 0.41, 1)');
+}
+
+.drawer__close button {
+  height: 60px;
+  width: 100%;
+  padding: 0 $gutter;
+  text-align: left;
+}
 
 /*============================================================================
   #Site Footer

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -62,102 +62,139 @@
 {% endcomment %}
 <body id="{{ page_title | handle }}" class="{% if customer %}customer-logged-in {% endif %}template-{{ template | replace: '.', ' ' | truncatewords: 1, '' | handle }}" >
 
-  <header class="site-header" role="banner">
-    <div class="wrapper">
-
-      <div class="grid--full">
-        <div class="grid__item large--one-half">
-          {% comment %}
-            Use the uploaded logo from theme settings if enabled.
-            Site name gets precedence with H1 tag on homepage, div on other pages.
-          {% endcomment %}
-          {% if template == 'index' %}
-            <h1 class="site-header__logo large--left" itemscope itemtype="http://schema.org/Organization">
-          {% else %}
-            <div class="h1 site-header__logo large--left" itemscope itemtype="http://schema.org/Organization">
-          {% endif %}
-            {% if settings.logo_use_image %}
-              <a href="/" itemprop="url">
-                <img src="{{ 'logo.png' | asset_url }}" alt="{{ shop.name }}" itemprop="logo">
-              </a>
-            {% else %}
-              <a href="/" itemprop="url">{{ shop.name }}</a>
-            {% endif %}
-          {% if template == 'index' %}
-            </h1>
-          {% else %}
-            </div>
-          {% endif %}
+  <div id="SiteContainer">
+    <div id="NavDrawer" class="drawer drawer--left">
+      <div class="drawer__inner">
+        <div class="drawer__close js-drawer-close">
+          <button type="button" class="icon-fallback-text">
+            <span class="icon icon-x" aria-hidden="true"></span>
+            <span class="fallback-text">{{ 'cart.general.close_cart' | t | json }}</span>
+          </button>
         </div>
-        <div class="grid__item large--one-half text-center large--text-right">
-          {% comment %}
-            Show number of items in the cart and total cost in the /cart link
-
-            Ajaxify Cart Notes:
-              - #cartToggle toggles cart visibility (drawer or modal)
-              - #cartCount updates the total number of items in the cart
-              - #cartCost updates the total cost of the cart
-              - Documentation:  http://shopify.com/timber#ajax-cart
-          {% endcomment %}
-          <a href="/cart" id="CartToggle">
-            <span class="icon-fallback-text">
-              <span class="icon icon-cart" aria-hidden="true"></span>
-            </span>
-            {{ 'layout.cart.title' | t }}
-            (<span id="CartCount">{{ cart.item_count }}</span>
-            {{ 'layout.cart.items_count' | t: count: cart.item_count }}
-            <span id="CartCost">{{ cart.total_price | money }}</span>)
-          </a>
-
-          {% comment %}
-            If customer accounts are enabled, provide login and create account links
-          {% endcomment %}
-          {% if shop.customer_accounts_enabled %}
-          <p class="site-header__text-links">
-            {% if customer %}
-              {% if customer.first_name != blank %}
-                {% capture first_name %}<a href="/account">{{ customer.first_name }}</a>{% endcapture %}
-                {{ 'layout.customer.logged_in_as_html' | t: first_name: first_name }}
-              {% else %}
-                <a href="/account">{{ 'layout.customer.account' | t }}</a>
-              {% endif %}
-              | {{ 'layout.customer.log_out' | t | customer_logout_link }}
-            {% else %}
-              {{ 'layout.customer.log_in' | t | customer_login_link }}
-              {% if shop.customer_accounts_optional %}
-              | {{ 'layout.customer.create_account' | t | customer_register_link }}
-              {% endif %}
-            {% endif %}
-          </p>
-          {% endif %}
-        </div>
+        {% include 'site-nav' %}
       </div>
-
     </div>
-  </header>
+    <div id="CartDrawer" class="drawer drawer--right">
+      <div class="drawer__close js-drawer-close">
+        <button type="button" class="icon-fallback-text">
+          <span class="icon icon-x" aria-hidden="true"></span>
+          <span class="fallback-text">{{ 'cart.general.close_cart' | t | json }}</span>
+        </button>
+      </div>
+    </div>
+    <div id="PageContainer" class="is-moved-by-drawer">
+      <header class="site-header" role="banner">
+        <div class="wrapper">
 
-  <nav class="nav-bar" role="navigation">
-    <div class="wrapper">
-      <div class="grid">
-        <div class="grid__item large--two-thirds">
-          {% include 'site-nav' %}
+          <div class="grid--full">
+            <div class="grid__item large--one-half">
+              {% comment %}
+                Use the uploaded logo from theme settings if enabled.
+                Site name gets precedence with H1 tag on homepage, div on other pages.
+              {% endcomment %}
+              {% if template == 'index' %}
+                <h1 class="site-header__logo large--left" itemscope itemtype="http://schema.org/Organization">
+              {% else %}
+                <div class="h1 site-header__logo large--left" itemscope itemtype="http://schema.org/Organization">
+              {% endif %}
+                {% if settings.logo_use_image %}
+                  <a href="/" itemprop="url">
+                    <img src="{{ 'logo.png' | asset_url }}" alt="{{ shop.name }}" itemprop="logo">
+                  </a>
+                {% else %}
+                  <a href="/" itemprop="url">{{ shop.name }}</a>
+                {% endif %}
+              {% if template == 'index' %}
+                </h1>
+              {% else %}
+                </div>
+              {% endif %}
+            </div>
+            <div class="grid__item large--one-half text-center large--text-right">
+              {% comment %}
+                Show number of items in the cart and total cost in the /cart link
+
+                Ajaxify Cart Notes:
+                  - #cartToggle toggles cart visibility (drawer or modal)
+                  - #cartCount updates the total number of items in the cart
+                  - #cartCost updates the total cost of the cart
+                  - Documentation:  http://shopify.com/timber#ajax-cart
+              {% endcomment %}
+              <a href="/cart" id="CartToggle">
+                <span class="icon-fallback-text">
+                  <span class="icon icon-cart" aria-hidden="true"></span>
+                </span>
+                {{ 'layout.cart.title' | t }}
+                (<span id="CartCount">{{ cart.item_count }}</span>
+                {{ 'layout.cart.items_count' | t: count: cart.item_count }}
+                <span id="CartCost">{{ cart.total_price | money }}</span>)
+              </a>
+
+              <a href="/cart" class="js-drawer-open-right" aria-controls="CartDrawer" aria-expanded="false">
+                <span class="icon-fallback-text">
+                  <span class="icon icon-cart" aria-hidden="true"></span>
+                </span>
+                {{ 'layout.cart.title' | t }}
+                (<span id="CartCount">{{ cart.item_count }}</span>
+                {{ 'layout.cart.items_count' | t: count: cart.item_count }}
+                <span id="CartCost">{{ cart.total_price | money }}</span>)
+              </a>
+
+              {% comment %}
+                If customer accounts are enabled, provide login and create account links
+              {% endcomment %}
+              {% if shop.customer_accounts_enabled %}
+              <p class="site-header__text-links">
+                {% if customer %}
+                  {% if customer.first_name != blank %}
+                    {% capture first_name %}<a href="/account">{{ customer.first_name }}</a>{% endcapture %}
+                    {{ 'layout.customer.logged_in_as_html' | t: first_name: first_name }}
+                  {% else %}
+                    <a href="/account">{{ 'layout.customer.account' | t }}</a>
+                  {% endif %}
+                  | {{ 'layout.customer.log_out' | t | customer_logout_link }}
+                {% else %}
+                  {{ 'layout.customer.log_in' | t | customer_login_link }}
+                  {% if shop.customer_accounts_optional %}
+                  | {{ 'layout.customer.create_account' | t | customer_register_link }}
+                  {% endif %}
+                {% endif %}
+              </p>
+              {% endif %}
+            </div>
+          </div>
+
         </div>
-        <div class="grid__item large--one-third">
-          <div class="nav-search">
-            {% include 'search-bar' %}
+      </header>
+
+      <nav class="nav-bar" role="navigation">
+        <div class="wrapper">
+          <div class="grid">
+            <div class="grid__item large--two-thirds">
+              <button type="button" class="js-drawer-open-left icon-fallback-text" aria-controls="NavDrawer" aria-expanded="false">
+                <span class="icon icon-hamburger" aria-hidden="true"></span>
+                <span class="fallback-text">Mobile Navigation</span>
+              </button>
+              {% include 'site-nav' %}
+            </div>
+            <div class="grid__item large--one-third">
+              <div class="nav-search">
+                {% include 'search-bar' %}
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      </nav>
+
+      <main class="wrapper main-content" role="main">
+
+        {{ content_for_layout }}
+
+      </main>
+
+      {% include 'footer' %}
     </div>
-  </nav>
-
-  <main class="wrapper main-content" role="main">
-
-    {{ content_for_layout }}
-
-  </main>
-
-  {% include 'footer' %}
+  </div>
 
   {{ 'timber.js' | asset_url | script_tag }}
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -115,21 +115,10 @@
                 Show number of items in the cart and total cost in the /cart link
 
                 Ajaxify Cart Notes:
-                  - #cartToggle toggles cart visibility (drawer or modal)
                   - #cartCount updates the total number of items in the cart
                   - #cartCost updates the total cost of the cart
                   - Documentation:  http://shopify.com/timber#ajax-cart
               {% endcomment %}
-              <a href="/cart" id="CartToggle">
-                <span class="icon-fallback-text">
-                  <span class="icon icon-cart" aria-hidden="true"></span>
-                </span>
-                {{ 'layout.cart.title' | t }}
-                (<span id="CartCount">{{ cart.item_count }}</span>
-                {{ 'layout.cart.items_count' | t: count: cart.item_count }}
-                <span id="CartCost">{{ cart.total_price | money }}</span>)
-              </a>
-
               <a href="/cart" class="js-drawer-open-right" aria-controls="CartDrawer" aria-expanded="false">
                 <span class="icon-fallback-text">
                   <span class="icon icon-cart" aria-hidden="true"></span>
@@ -232,7 +221,6 @@
           addToCartSelector: '#AddToCart',
           cartCountSelector: '#CartCount',
           cartCostSelector: '#CartCost',
-          toggleCartButton: '#CartToggle',
           useCartTemplate: true,
           btnClass: 'btn',
           moneyFormat: {{ shop.money_format | json }},


### PR DESCRIPTION
Demo - http://carson-blank.myshopify.com/

##### Drawer stuff:
- Minimized replaceUrlParam function, added [prepareTransition](https://github.com/snookca/prepareTransition)
- `timber.drawersInit` sets up multiple drawers (in this case menu and cart)
- use `Drawers` module from [Marketing Assets](https://github.com/Shopify/marketing_assets/blob/f6c830aff2809eabf64d72a0ca3ece345f32aac5/app/assets/javascripts/marketing_assets/modules/drawers.js)
  - JS slightly trimmed down because of the original module using other asset properties/variables
  - Pulled in the CSS and animations from there too

##### Non drawer stuff:
- Base button style
- Added transform mixin

Ignore the markup changes in `theme.liquid` for now. It will likely change a few more times when the cart ajax cart is introduced.