### PR TITLE
Add the URL input type

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1239,6 +1239,7 @@ input[type="file"],
 input[type="number"],
 input[type="tel"],
 input[type="submit"],
+input[type="url"],
 textarea {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -1299,6 +1300,7 @@ input[type="email"],
 input[type="file"],
 input[type="number"],
 input[type="tel"],
+input[type="url"],
 textarea,
 select {
   border: 1px solid $colorBorder;
@@ -1418,6 +1420,7 @@ form.form-horizontal,
   input[type="file"],
   input[type="number"],
   input[type="tel"],
+  input[type="url"],
   textarea,
   select,
   label {
@@ -1435,6 +1438,7 @@ input[type="email"],
 input[type="file"],
 input[type="number"],
 input[type="tel"],
+input[type="url"],
 textarea {
   &.error {
     border-color: $errorRed;


### PR DESCRIPTION
Adds a URL input type to the reset - especially needed when embedding MailChimp forms to get a uniformed look.