### PR TITLE
Use max sale price to accomodate variants

### DIFF
--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -25,7 +25,7 @@
   Check if the product is on sale and set a variable to be used below.
 {% endcomment %}
 {% assign on_sale = false %}
-{% if product.compare_at_price > product.price %}
+{% if product.compare_at_price_max > product.price %}
   {% assign on_sale = true %}
 {% endif %}
 
@@ -72,7 +72,7 @@
       <br><strong>{{ 'products.product.sold_out' | t }}</strong>
     {% endif %}
     {% if on_sale %}
-      {% assign sale_price =  product.compare_at_price | money %}
+      {% assign sale_price =  product.compare_at_price_max | money %}
       <br>{{ 'products.product.on_sale_from_html' | t: price: sale_price }}
     {% endif %}
   </p>

--- a/snippets/product-list-item.liquid
+++ b/snippets/product-list-item.liquid
@@ -10,7 +10,7 @@
   Check if the product is on sale and set a variable to be used below.
 {% endcomment %}
 {% assign on_sale = false %}
-{% if product.compare_at_price > product.price %}
+{% if product.compare_at_price_max > product.price %}
   {% assign on_sale = true %}
 {% endif %}
 
@@ -66,7 +66,7 @@
         <br><strong>{{ 'products.product.sold_out' | t }}</strong>
       {% endif %}
       {% if on_sale %}
-        {% assign sale_price =  product.compare_at_price | money %}
+        {% assign sale_price =  product.compare_at_price_max | money %}
         <br>{{ 'products.product.on_sale_from_html' | t: price: sale_price }}
       {% endif %}
     </div>

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -94,11 +94,11 @@
           {% comment %}
             Optionally show the 'compare at' or original price of the product.
           {% endcomment %}
-          <span id="ProductPrice" class="h2{% if product.compare_at_price > product.price %} on-sale{% endif %}" itemprop="price">
+          <span id="ProductPrice" class="h2{% if product.compare_at_price_max > product.price %} on-sale{% endif %}" itemprop="price">
             {{ product.price | money }}
           </span>
 
-          {% if product.compare_at_price > product.price %}
+          {% if product.compare_at_price_max > product.price %}
             <p id="ComparePrice">
               {{ 'products.product.compare_at' | t }} {{ product.compare_at_price_max | money }}
             </p>


### PR DESCRIPTION
@carolineschnapp This is why I asked. Should `product.compare_at_price` always be `product.compare_at_price_max`?

cc @stevebosworth @fredryk 