### PR TITLE
Reudced selector specificity. New form and list defaults.

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1218,7 +1218,7 @@ img.auto,
   #Forms
 ==============================================================================*/
 form {
-  margin-bottom: $gutter;
+  margin-bottom: 0;
 }
 
 /*================ Prevent zoom on touch devices in active inputs ================*/
@@ -1440,7 +1440,6 @@ label.error {
 
 .input-group .input-group-field {
   width: 100%;
-  margin-bottom: 0;
 }
 
 .input-group-btn {
@@ -1825,11 +1824,6 @@ label.error {
     padding: 0 0 ($gutter / 2);
     margin: 0 auto;
     text-align: center;
-  }
-
-  .input-group,
-  .input-group-field {
-    margin-bottom: 0;
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -978,14 +978,6 @@ hr {
     margin-bottom: $gutter / 2;
   }
 
-  ul, ol {
-    margin-left: 35px;
-  }
-
-  ul {
-    @extend ul.disc;
-  }
-
   li {
     margin-bottom: 0.4em;
   }
@@ -1103,17 +1095,19 @@ html input[disabled] {
   #Lists
 ==============================================================================*/
 ul, ol {
-  margin: 0 0 $gutter;
+  margin: 0 0 $gutter 20px;
   padding: 0;
+
+  &.inline-list {
+    margin-left: 0;
+  }
 }
 
-ul { list-style: none outside; }
 ol { list-style: decimal; }
 ul ul, ul ol,
 ol ol, ol ul { margin: 4px 0 5px 20px; }
 li { margin-bottom: 0.25em; }
 
-ol, ul.square, ul.disc { margin-left: 20px; }
 ul.square { list-style: square outside; }
 ul.disc { list-style: disc outside; }
 ol.alpha { list-style: lower-alpha outside; }

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1011,7 +1011,8 @@ html input[disabled] {
   cursor: default;
 }
 
-.btn {
+.btn,
+.rte .btn {
   display: inline-block;
   padding: 8px 10px;
   width: auto;
@@ -1052,7 +1053,8 @@ html input[disabled] {
   }
 }
 
-.btn--secondary {
+.btn--secondary,
+.rte .btn--secondary {
   @extend .btn;
   background-color: $colorBtnSecondary;
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1097,11 +1097,11 @@ html input[disabled] {
   #Lists
 ==============================================================================*/
 ul, ol {
-  margin: 0 0 $gutter 20px;
+  margin: 0 0 ($gutter / 2) 20px;
   padding: 0;
 
   &.inline-list {
-    margin-left: 0;
+    margin: 0;
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -41,7 +41,6 @@
   #Collection Filters
   #Breadcrumbs
   #Product Page
-  #Blogs and Comments
   #Notes and Form Feedback
   #Cart Page
 ==============================================================================*/
@@ -1840,7 +1839,6 @@ label.error {
 ==============================================================================*/
 .site-footer {
   background-color: $colorFooterBg;
-  border-top: 1px solid $colorBorder;
   padding: $gutter 0;
   color: $colorFooterText;
 
@@ -1929,18 +1927,6 @@ label.error {
 
   li {
     margin-bottom: $gutter;
-  }
-}
-
-/*============================================================================
-  #Blogs and Comments
-==============================================================================*/
-.comment {
-  margin-bottom: $gutter;
-
-  & + & {
-    border-top: 1px solid $colorBorder;
-    padding-top: $gutter;
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1022,6 +1022,7 @@ html input[disabled] {
 .btn {
   display: inline-block;
   padding: 8px 10px;
+  width: auto;
   margin: 0;
   line-height: 1.42;
   font-weight: bold;
@@ -1059,8 +1060,7 @@ html input[disabled] {
   }
 }
 
-.btn--secondary,
-input.btn--secondary {
+.btn--secondary {
   @extend .btn;
   background-color: $colorBtnSecondary;
 
@@ -1223,45 +1223,11 @@ form {
   margin-bottom: $gutter;
 }
 
+button,
 input,
-textarea,
-button,
-select {
-  font-size: 1em;
-}
-
-button,
-input[type="text"],
-input[type="search"],
-input[type="password"],
-input[type="email"],
-input[type="file"],
-input[type="number"],
-input[type="tel"],
-input[type="submit"],
-input[type="url"],
 textarea {
   -webkit-appearance: none;
   -moz-appearance: none;
-}
-
-input,
-textarea,
-select,
-fieldset {
-  border-radius: $radius;
-  max-width: 100%;
-
-  &.input-full {
-    width: 100%;
-  }
-}
-
-input,
-select,
-textarea {
-  padding: 8px 10px;
-  line-height: 1.42;
 }
 
 fieldset {
@@ -1288,19 +1254,8 @@ input[type="submit"] {
   cursor: pointer;
 }
 
-input[type="submit"] {
-  @extend .btn;
-}
-
 /*================ Input width and border ================*/
-input[type="text"],
-input[type="search"],
-input[type="password"],
-input[type="email"],
-input[type="file"],
-input[type="number"],
-input[type="tel"],
-input[type="url"],
+input,
 textarea,
 select {
   border: 1px solid $colorBorder;
@@ -1308,6 +1263,8 @@ select {
   max-width: 100%;
   display: block;
   margin: 0 0 1em;
+  padding: 8px 10px;
+  border-radius: $radius;
 
   &:focus {
     border: 1px solid darken($colorBorder, 10%);
@@ -1319,6 +1276,10 @@ select {
     background-color: $disabledGrey;
     border-color: $disabledBorder;
   }
+
+  &.input-full {
+    width: 100%;
+  }
 }
 
 textarea {
@@ -1328,8 +1289,19 @@ textarea {
 input[type="checkbox"],
 input[type="radio"] {
   display: inline;
-  margin: 0;
+  margin: 0 10px 0 0;
   padding: 0;
+  width: auto;
+}
+
+input[type="checkbox"] {
+  -webkit-appearance: checkbox;
+  -moz-appearance: checkbox;
+}
+
+input[type="radio"] {
+  -webkit-appearance: radio;
+  -moz-appearance: radio;
 }
 
 select {
@@ -1394,18 +1366,8 @@ legend {
   }
 }
 
-/*================ We don't want the same label treatment for checkboxes/radios ================*/
-input[type="checkbox"] + label,
-input[type="radio"] + label {
-  font-weight: normal;
-}
-
 label[for] {
   cursor: pointer;
-}
-
-.label-hint {
-  color: #999;
 }
 
 /*================ Horizontal Form ================*/
@@ -1413,14 +1375,7 @@ form.form-horizontal,
 .form-horizontal {
   margin-bottom: 0;
 
-  input[type="text"],
-  input[type="search"],
-  input[type="password"],
-  input[type="email"],
-  input[type="file"],
-  input[type="number"],
-  input[type="tel"],
-  input[type="url"],
+  input,
   textarea,
   select,
   label {
@@ -1431,14 +1386,7 @@ form.form-horizontal,
 }
 
 /*================ Error styles ================*/
-input[type="text"],
-input[type="search"],
-input[type="password"],
-input[type="email"],
-input[type="file"],
-input[type="number"],
-input[type="tel"],
-input[type="url"],
+input,
 textarea {
   &.error {
     border-color: $errorRed;

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1018,7 +1018,7 @@ html input[disabled] {
   margin: 0;
   line-height: 1.42;
   font-weight: bold;
-  text-decoration: none;
+  text-decoration: none!important;
   text-align: center;
   vertical-align: middle;
   white-space: nowrap;
@@ -1111,6 +1111,10 @@ li { margin-bottom: 0.25em; }
 ul.square { list-style: square outside; }
 ul.disc { list-style: disc outside; }
 ol.alpha { list-style: lower-alpha outside; }
+.no-bullets {
+  list-style: none outside;
+  margin-left: 0;
+}
 
 .inline-list li {
   display: inline-block;

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1217,11 +1217,25 @@ form {
   margin-bottom: $gutter;
 }
 
+@include at-query($max, $medium) {
+  input,
+  textarea {
+    font-size: 16px;
+  }
+}
+
 button,
 input,
 textarea {
   -webkit-appearance: none;
   -moz-appearance: none;
+}
+
+button {
+  background: none;
+  border: none;
+  display: inline-block;
+  cursor: pointer;
 }
 
 fieldset {
@@ -1234,21 +1248,11 @@ legend {
   padding: 0;
 }
 
-optgroup {
-  font-weight: bold;
-}
-
-input {
-  display: inline-block;
-  width: auto;
-}
-
 button,
 input[type="submit"] {
   cursor: pointer;
 }
 
-/*================ Input width and border ================*/
 input,
 textarea,
 select {
@@ -1280,6 +1284,7 @@ textarea {
   min-height: 100px;
 }
 
+/*================ Input element overrides ================*/
 input[type="checkbox"],
 input[type="radio"] {
   display: inline;
@@ -1296,6 +1301,11 @@ input[type="checkbox"] {
 input[type="radio"] {
   -webkit-appearance: radio;
   -moz-appearance: radio;
+}
+
+input[type="image"] {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 select {
@@ -1320,6 +1330,10 @@ select {
     padding-right: 10px;
     background-image: none;
   }
+}
+
+optgroup {
+  font-weight: bold;
 }
 
 // Force option color (affects IE only)

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1221,6 +1221,7 @@ form {
   margin-bottom: $gutter;
 }
 
+/*================ Prevent zoom on touch devices in active inputs ================*/
 @include at-query($max, $medium) {
   input,
   textarea {
@@ -1261,10 +1262,7 @@ input,
 textarea,
 select {
   border: 1px solid $colorBorder;
-  width: 100%;
   max-width: 100%;
-  display: block;
-  margin: 0 0 1em;
   padding: 8px 10px;
   border-radius: $radius;
 
@@ -1292,7 +1290,7 @@ textarea {
 input[type="checkbox"],
 input[type="radio"] {
   display: inline;
-  margin: 0 10px 0 0;
+  margin: 0 8px 0 0;
   padding: 0;
   width: auto;
 }
@@ -1351,30 +1349,20 @@ select::-ms-expand {
 }
 
 /*================ Form labels ================*/
-label,
-legend {
-  display: block;
-  margin-bottom: 2px;
-  font-weight: bold;
+.label-hidden {
+  display: inline-block;
+  height: 0;
+  width: 0;
+  margin-bottom: 0;
+  overflow: hidden;
 
-  &.inline {
-    display: inline;
-  }
-
-  .form-horizontal &.label--hidden,
-  &.label--hidden {
-    height: 0;
-    width: 0;
-    margin-bottom: 0;
-    overflow: hidden;
-
-    .ie9 &,
-    .lt-ie9 & {
-      height: auto;
-      width: auto;
-      margin-bottom: 2px;
-      overflow: visible;
-    }
+  // No placeholders, so force show labels
+  .ie9 &,
+  .lt-ie9 & {
+    height: auto;
+    width: auto;
+    margin-bottom: 2px;
+    overflow: visible;
   }
 }
 
@@ -1383,22 +1371,18 @@ label[for] {
 }
 
 /*================ Horizontal Form ================*/
-form.form-horizontal,
-.form-horizontal {
-  margin-bottom: 0;
-
+.form-vertical {
   input,
-  textarea,
   select,
-  label {
-    display: inline-block;
-    margin-bottom: 0;
-    width: auto;
+  textarea {
+    display: block;
+    margin-bottom: 10px;
   }
 }
 
 /*================ Error styles ================*/
 input,
+select,
 textarea {
   &.error {
     border-color: $errorRed;

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1101,7 +1101,7 @@ ul, ol {
   padding: 0;
 
   &.inline-list {
-    margin: 0;
+    margin-left: 0;
   }
 }
 
@@ -1351,7 +1351,7 @@ select::-ms-expand {
 }
 
 /*================ Form labels ================*/
-.label-hidden {
+.label--hidden {
   display: inline-block;
   height: 0;
   width: 0;
@@ -1379,6 +1379,11 @@ label[for] {
   textarea {
     display: block;
     margin-bottom: 10px;
+  }
+
+  input[type="radio"],
+  input[type="checkbox"] {
+    display: inline-block;
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1018,7 +1018,7 @@ html input[disabled] {
   margin: 0;
   line-height: 1.42;
   font-weight: bold;
-  text-decoration: none!important;
+  text-decoration: none;
   text-align: center;
   vertical-align: middle;
   white-space: nowrap;

--- a/snippets/blog-sidebar.liquid
+++ b/snippets/blog-sidebar.liquid
@@ -3,7 +3,7 @@
   Recent blog posts
 {% endcomment %}
 <h4>{{ 'blogs.sidebar.recent_articles' | t }}</h4>
-<ul>
+<ul class="no-bullets">
   {% for article in blogs[blog.handle].articles limit:6 %}
     <li>
       <a href="{{ article.url }}">{{ article.title }}</a>
@@ -18,7 +18,7 @@
 {% endcomment %}
 {% if blog.all_tags.size > 0 %}
   <h4>{{ 'blogs.sidebar.categories' | t }}</h4>
-  <ul>
+  <ul class="no-bullets">
     {% for tag in blog.all_tags %}
       {% if current_tags contains tag %}
       <li>{{ tag }}</li>

--- a/snippets/footer.liquid
+++ b/snippets/footer.liquid
@@ -32,7 +32,7 @@
       {% if settings.footer_quicklinks_enable %}
         <div class="grid__item {{ footer_column_width }}">
           <h3>{{ 'layout.footer.linklist_title' | t }}</h3>
-          <ul>
+          <ul class="no-bullets">
             {% for link in linklists[settings.footer_quicklinks_linklist].links %}
               <li><a href="{{ link.url }}">{{ link.title }}</a></li>
             {% endfor %}

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -109,6 +109,10 @@
                 <li id="{{ comment.id }}" class="comment{% unless number_of_comments > article.comments_count %}{% if forloop.first %} first{% endif %}{% endunless %}{% if forloop.last %} last {% endif %}">
                   {% include 'comment' %}
                 </li>
+
+                {% unless forloop.last %}
+                  <li><hr></li>
+                {% endunless %}
               {% endfor %}
             </ul>
 

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -42,7 +42,7 @@
     {% comment %}
       Show off meta information like comments and tags.
     {% endcomment %}
-    <ul>
+    <ul class="inline-list">
       {% include 'tags-article' %}
     </ul>
 
@@ -92,7 +92,7 @@
           {% endif %}
 
           {% if number_of_comments > 0 %}
-            <ul>
+            <ul class="no-bullets">
               {% comment %}
                 If a comment was just submitted with no blank field, show it.
               {% endcomment %}
@@ -126,50 +126,52 @@
           {% comment %}
             Comment submission form
           {% endcomment %}
-          {% form 'new_comment', article %}
+          <div class="form-vertical">
+            {% form 'new_comment', article %}
 
-            {% comment %}
-              #AddCommentTitle is used simply as an anchor link
-            {% endcomment %}
-            <h3 id="AddCommentTitle">{{ 'blogs.comments.title' | t }}</h3>
+              {% comment %}
+                #AddCommentTitle is used simply as an anchor link
+              {% endcomment %}
+              <h3 id="AddCommentTitle">{{ 'blogs.comments.title' | t }}</h3>
 
-            {{ form.errors | default_errors }}
+              {{ form.errors | default_errors }}
 
-            <div class="grid">
+              <div class="grid">
 
-              <div class="grid__item large--one-half">
-                <label for="CommentAuthor" class="label--hidden">{{ 'blogs.comments.name' | t }}</label>
-                <input {% if form.errors contains "author" %} class="error"{% endif %} type="text" name="comment[author]" placeholder="{{ 'blogs.comments.name' | t }}" id="CommentAuthor" value="{{ form.author }}" autocapitalize="words">
+                <div class="grid__item large--one-half">
+                  <label for="CommentAuthor" class="label--hidden">{{ 'blogs.comments.name' | t }}</label>
+                  <input {% if form.errors contains "author" %} class="error"{% endif %} type="text" name="comment[author]" placeholder="{{ 'blogs.comments.name' | t }}" id="CommentAuthor" value="{{ form.author }}" autocapitalize="words">
 
-                <label for="CommentEmail" class="label--hidden">{{ 'blogs.comments.email' | t }}</label>
-                <input {% if form.errors contains "email" %} class="error"{% endif %} type="email" name="comment[email]" placeholder="{{ 'blogs.comments.email' | t }}" id="CommentEmail" value="{{ form.email }}" autocorrect="off" autocapitalize="off">
+                  <label for="CommentEmail" class="label--hidden">{{ 'blogs.comments.email' | t }}</label>
+                  <input {% if form.errors contains "email" %} class="error"{% endif %} type="email" name="comment[email]" placeholder="{{ 'blogs.comments.email' | t }}" id="CommentEmail" value="{{ form.email }}" autocorrect="off" autocapitalize="off">
+                </div>
+
+                <div class="grid__item">
+                  <label for="CommentBody" class="label--hidden">{{ 'blogs.comments.message' | t }}</label>
+                  <textarea {% if form.errors contains "body" %} class="error"{% endif %} name="comment[body]" id="CommentBody" placeholder="{{ 'blogs.comments.message' | t }}">{{ form.body }}</textarea>
+                </div>
+
               </div>
 
-              <div class="grid__item">
-                <label for="CommentBody" class="label--hidden">{{ 'blogs.comments.message' | t }}</label>
-                <textarea {% if form.errors contains "body" %} class="error"{% endif %} name="comment[body]" id="CommentBody" placeholder="{{ 'blogs.comments.message' | t }}">{{ form.body }}</textarea>
-              </div>
+              {% if blog.moderated? %}
+                <p>{{ 'blogs.comments.moderated' | t }}</p>
+              {% endif %}
 
-            </div>
+              <input type="submit" class="btn" value="{{ 'blogs.comments.post' | t }}">
 
-            {% if blog.moderated? %}
-              <p>{{ 'blogs.comments.moderated' | t }}</p>
-            {% endif %}
+              {% comment %}
+                Assign variable to be used after timber.init() is run in theme.liquid
+              {% endcomment %}
+              {% if form.errors %}
+                {% assign newHash = 'AddCommentTitle' %}
+              {% endif %}
 
-            <input type="submit" class="btn" value="{{ 'blogs.comments.post' | t }}">
+              {% if form.posted_successfully? %}
+                {% assign newHash = 'Comments' %}
+              {% endif %}
 
-            {% comment %}
-              Assign variable to be used after timber.init() is run in theme.liquid
-            {% endcomment %}
-            {% if form.errors %}
-              {% assign newHash = 'AddCommentTitle' %}
-            {% endif %}
-
-            {% if form.posted_successfully? %}
-              {% assign newHash = 'Comments' %}
-            {% endif %}
-
-          {% endform %}
+            {% endform %}
+          </div>
 
         </div>
       {% endpaginate %}

--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -52,10 +52,7 @@
       {% comment %}
         Show off meta information like number of comments and tags.
       {% endcomment %}
-      <ul>
-        {% comment %}
-          comments_enabled? and moderated? are the only instances of punctuation in liquid tags.
-        {% endcomment %}
+      <ul class="inline-list">
         {% if blog.comments_enabled? %}
         <li>
           <a href="{{ article.url }}#Comments">

--- a/templates/customers/activate_account.liquid
+++ b/templates/customers/activate_account.liquid
@@ -10,23 +10,25 @@
     {% comment %}
       This form must use 'activate_customer_password'
     {% endcomment %}
-    {% form 'activate_customer_password' %}
+    <div class="form-vertical">
+      {% form 'activate_customer_password' %}
 
-      {{ form.errors | default_errors }}
+        {{ form.errors | default_errors }}
 
-      <label for="CustomerPassword" class="label--hidden">{{ 'customer.activate_account.password' | t }}</label>
-      <input type="password" value="" name="customer[password]" id="CustomerPassword" placeholder="{{ 'customer.activate_account.password' | t }}">
+        <label for="CustomerPassword" class="label--hidden">{{ 'customer.activate_account.password' | t }}</label>
+        <input type="password" value="" name="customer[password]" id="CustomerPassword" class="input-full" placeholder="{{ 'customer.activate_account.password' | t }}">
 
-      <label for="CustomerPasswordConfirmation" class="label--hidden">{{ 'customer.activate_account.password_confirm' | t }}</label>
-      <input type="password" value="" name="customer[password_confirmation]" id="CustomerPasswordConfirmation" placeholder="{{ 'customer.activate_account.password_confirm' | t }}">
+        <label for="CustomerPasswordConfirmation" class="label--hidden">{{ 'customer.activate_account.password_confirm' | t }}</label>
+        <input type="password" value="" name="customer[password_confirmation]" id="CustomerPasswordConfirmation" class="input-full" placeholder="{{ 'customer.activate_account.password_confirm' | t }}">
 
-      <div class="text-center">
-        <p>
-          <input type="submit" class="btn" value="{{ 'customer.activate_account.submit' | t }}">
-        </p>
-        <input type="submit" class="btn--secondary" name="decline" value="{{ 'customer.activate_account.cancel' | t }}">
-      </div>
-    {% endform %}
+        <div class="text-center">
+          <p>
+            <input type="submit" class="btn btn--full" value="{{ 'customer.activate_account.submit' | t }}">
+          </p>
+          <input type="submit" class="btn--secondary" name="decline" value="{{ 'customer.activate_account.cancel' | t }}">
+        </div>
+      {% endform %}
+    </div>
 
   </div>
 </div>

--- a/templates/customers/addresses.liquid
+++ b/templates/customers/addresses.liquid
@@ -29,7 +29,7 @@
     {% comment %}
       Add address form, hidden by default
     {% endcomment %}
-    <div id="AddAddress" style="display: none;">
+    <div id="AddAddress" class="form-vertical" style="display: none;">
       {% form 'customer_address', customer.new_address %}
 
         <h2>{{ 'customer.addresses.add_new' | t }}</h2>
@@ -38,49 +38,49 @@
 
           <div class="grid__item one-half small--one-whole">
             <label for="AddressFirstNameNew">{{ 'customer.addresses.first_name' | t }}</label>
-            <input type="text" id="AddressFirstNameNew" class="address_form" name="address[first_name]" value="{{form.first_name}}" autocapitalize="words">
+            <input type="text" id="AddressFirstNameNew" class="input-full" name="address[first_name]" value="{{form.first_name}}" autocapitalize="words">
           </div>
 
           <div class="grid__item one-half small--one-whole">
             <label for="AddressLastNameNew">{{ 'customer.addresses.last_name' | t }}</label>
-            <input type="text" id="AddressLastNameNew" class="address_form" name="address[last_name]" value="{{form.last_name}}" autocapitalize="words">
+            <input type="text" id="AddressLastNameNew" class="input-full" name="address[last_name]" value="{{form.last_name}}" autocapitalize="words">
           </div>
 
         </div>
 
         <label for="AddressCompanyNew">{{ 'customer.addresses.company' | t }}</label>
-        <input type="text" id="AddressCompanyNew" class="address_form" name="address[company]" value="{{form.company}}" autocapitalize="words">
+        <input type="text" id="AddressCompanyNew" class="input-full" name="address[company]" value="{{form.company}}" autocapitalize="words">
 
         <label for="AddressAddress1New">{{ 'customer.addresses.address1' | t }}</label>
-        <input type="text" id="AddressAddress1New" class="address_form" name="address[address1]" value="{{form.address1}}" autocapitalize="words">
+        <input type="text" id="AddressAddress1New" class="input-full" name="address[address1]" value="{{form.address1}}" autocapitalize="words">
 
         <label for="AddressAddress2New">{{ 'customer.addresses.address2' | t }}</label>
-        <input type="text" id="AddressAddress2New" class="address_form" name="address[address2]" value="{{form.address2}}" autocapitalize="words">
+        <input type="text" id="AddressAddress2New" class="input-full" name="address[address2]" value="{{form.address2}}" autocapitalize="words">
 
         <div class="grid">
           <div class="grid__item large--one-half">
             <label for="AddressCityNew">{{ 'customer.addresses.city' | t }}</label>
-            <input type="text" id="AddressCityNew" class="address_form" name="address[city]" value="{{form.city}}" autocapitalize="words">
+            <input type="text" id="AddressCityNew" class="input-full" name="address[city]" value="{{form.city}}" autocapitalize="words">
           </div>
 
           <div class="grid__item large--one-half">
             <label for="AddressCountryNew">{{ 'customer.addresses.country' | t }}</label>
-            <select id="AddressCountryNew" name="address[country]" data-default="{{form.country}}">{{ country_option_tags }}</select>
+            <select id="AddressCountryNew" class="input-full" name="address[country]" data-default="{{form.country}}">{{ country_option_tags }}</select>
           </div>
 
           <div class="grid__item" id="AddressProvinceContainerNew" style="display:none">
             <label for="AddressProvinceNew">{{ 'customer.addresses.province' | t }}</label>
-            <select id="AddressProvinceNew" class="address_form" name="address[province]" data-default="{{form.province}}"></select>
+            <select id="AddressProvinceNew" class="input-full" name="address[province]" data-default="{{form.province}}"></select>
           </div>
 
           <div class="grid__item large--one-half">
             <label for="AddressZipNew">{{ 'customer.addresses.zip' | t }}</label>
-            <input type="text" id="AddressZipNew" class="address_form" name="address[zip]" value="{{form.zip}}" autocapitalize="characters">
+            <input type="text" id="AddressZipNew" class="input-full" name="address[zip]" value="{{form.zip}}" autocapitalize="characters">
           </div>
 
           <div class="grid__item large--one-half">
             <label for="AddressPhoneNew">{{ 'customer.addresses.phone' | t }}</label>
-            <input type="tel" id="AddressPhoneNew" class="address_form" name="address[phone]" value="{{form.phone}}">
+            <input type="tel" id="AddressPhoneNew" class="input-full" name="address[phone]" value="{{form.phone}}">
           </div>
         </div>
 
@@ -126,7 +126,7 @@
           {{ 'customer.addresses.delete' | t | delete_customer_address_link: address.id }}
         </p>
 
-        <div id="EditAddress_{{address.id}}" style="display:none;">
+        <div id="EditAddress_{{address.id}}" class="form-vertical" style="display:none;">
           {% form 'customer_address', address %}
 
             <h4>{{ 'customer.addresses.edit_address' | t }}</h4>
@@ -134,44 +134,44 @@
             <div class="grid">
               <div class="grid__item one-half small--one-whole">
                 <label for="AddressFirstName_{{form.id}}">{{ 'customer.addresses.first_name' | t }}</label>
-                <input type="text" id="AddressFirstName_{{form.id}}" class="address_form" name="address[first_name]" value="{{form.first_name}}" autocapitalize="words">
+                <input type="text" id="AddressFirstName_{{form.id}}" class="input-full" name="address[first_name]" value="{{form.first_name}}" autocapitalize="words">
               </div>
 
               <div class="grid__item one-half small--one-whole">
                 <label for="AddressLastName_{{form.id}}">{{ 'customer.addresses.last_name' | t }}</label>
-                <input type="text" id="AddressLastName_{{form.id}}" class="address_form" name="address[last_name]" value="{{form.last_name}}" autocapitalize="words">
+                <input type="text" id="AddressLastName_{{form.id}}" class="input-full" name="address[last_name]" value="{{form.last_name}}" autocapitalize="words">
               </div>
             </div>
 
             <label for="AddressCompany_{{form.id}}">{{ 'customer.addresses.company' | t }}</label>
-            <input type="text" id="AddressCompany_{{form.id}}" class="address_form" name="address[company]" value="{{form.company}}" autocapitalize="words">
+            <input type="text" id="AddressCompany_{{form.id}}" class="input-full" name="address[company]" value="{{form.company}}" autocapitalize="words">
 
             <label for="AddressAddress1_{{form.id}}">{{ 'customer.addresses.address1' | t }}</label>
-            <input type="text" id="AddressAddress1_{{form.id}}" class="address_form" name="address[address1]" value="{{form.address1}}" autocapitalize="words">
+            <input type="text" id="AddressAddress1_{{form.id}}" class="input-full" name="address[address1]" value="{{form.address1}}" autocapitalize="words">
 
             <label for="AddressAddress2_{{form.id}}">{{ 'customer.addresses.address2' | t }}</label>
-            <input type="text" id="AddressAddress2_{{form.id}}" class="address_form" name="address[address2]" value="{{form.address2}}" autocapitalize="words">
+            <input type="text" id="AddressAddress2_{{form.id}}" class="input-full" name="address[address2]" value="{{form.address2}}" autocapitalize="words">
 
             <label for="AddressCity_{{form.id}}">{{ 'customer.addresses.city' | t }}</label>
-            <input type="text" id="AddressCity_{{form.id}}" class="address_form" name="address[city]" value="{{form.city}}" autocapitalize="words">
+            <input type="text" id="AddressCity_{{form.id}}" class="input-full" name="address[city]" value="{{form.city}}" autocapitalize="words">
 
             <label for="AddressCountry_{{form.id}}">{{ 'customer.addresses.country' | t }}</label>
-            <select id="AddressCountry_{{form.id}}" name="address[country]" data-default="{{form.country}}">{{ country_option_tags }}</select>
+            <select id="AddressCountry_{{form.id}}" class="input-full" name="address[country]" data-default="{{form.country}}">{{ country_option_tags }}</select>
 
             <div id="AddressProvinceContainer_{{form.id}}" style="display:none">
               <label for="AddressProvince_{{form.id}}">{{ 'customer.addresses.province' | t }}</label>
-              <select id="AddressProvince_{{form.id}}" class="address_form" name="address[province]" data-default="{{form.province}}"></select>
+              <select id="AddressProvince_{{form.id}}" class="input-full" name="address[province]" data-default="{{form.province}}"></select>
             </div>
 
             <div class="grid">
               <div class="grid__item one-half small--one-whole">
                 <label for="AddressZip_{{form.id}}">{{ 'customer.addresses.zip' | t }}</label>
-                <input type="text" id="AddressZip_{{form.id}}" class="address_form" name="address[zip]" value="{{form.zip}}" autocapitalize="characters">
+                <input type="text" id="AddressZip_{{form.id}}" class="input-full" name="address[zip]" value="{{form.zip}}" autocapitalize="characters">
               </div>
 
               <div class="grid__item one-half small--one-whole">
                 <label for="AddressPhone_{{form.id}}">{{ 'customer.addresses.phone' | t }}</label>
-                <input type="tel" id="AddressPhone_{{form.id}}" class="address_form" name="address[phone]" value="{{form.phone}}">
+                <input type="tel" id="AddressPhone_{{form.id}}" class="input-full" name="address[phone]" value="{{form.phone}}">
               </div>
             </div>
 

--- a/templates/customers/login.liquid
+++ b/templates/customers/login.liquid
@@ -14,7 +14,7 @@
       {{ 'customer.recover_password.success' | t }}
     </div>
 
-    <div id="CustomerLoginForm">
+    <div id="CustomerLoginForm" class="form-vertical">
       {% form 'customer_login' %}
 
         <h1>{{ 'customer.login.title' | t }}</h1>
@@ -22,12 +22,12 @@
         {{ form.errors | default_errors }}
 
         <label for="CustomerEmail" class="label--hidden">{{ 'customer.login.email' | t }}</label>
-        <input type="email" name="customer[email]" id="CustomerEmail" placeholder="{{ 'customer.login.email' | t }}"{% if form.errors contains "email" %} class="error"{% endif %} autocorrect="off" autocapitalize="off" autofocus>
+        <input type="email" name="customer[email]" id="CustomerEmail" class="input-full{% if form.errors contains 'email' %} error{% endif %}" placeholder="{{ 'customer.login.email' | t }}" autocorrect="off" autocapitalize="off" autofocus>
 
         {% if form.password_needed %}
 
           <label for="CustomerPassword" class="label--hidden">{{ 'customer.login.password' | t }}</label>
-          <input type="password" value="" name="customer[password]" id="CustomerPassword" placeholder="{{ 'customer.login.password' | t }}" {% if form.errors contains "password" %} class="error"{% endif %}>
+          <input type="password" value="" name="customer[password]" id="CustomerPassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.login.password' | t }}">
 
           <p>
             <a href="#recover" id="RecoverPassword">{{ 'customer.login.forgot_password' | t }}</a>
@@ -36,7 +36,7 @@
         {% endif %}
 
         <p>
-          <input type="submit" class="btn" value="{{ 'customer.login.sign_in' | t }}">
+          <input type="submit" class="btn btn--full" value="{{ 'customer.login.sign_in' | t }}">
         </p>
         <a href="{{ shop.url }}">{{ 'customer.login.cancel' | t }}</a>
 

--- a/templates/customers/register.liquid
+++ b/templates/customers/register.liquid
@@ -7,28 +7,30 @@
 
     <h1>{{ 'customer.register.title' | t }}</h1>
 
-    {% form 'create_customer' %}
+    <div class="form-vertical">
+      {% form 'create_customer' %}
 
-      {{ form.errors | default_errors }}
+        {{ form.errors | default_errors }}
 
-      <label for="FirstName" class="label--hidden">{{ 'customer.register.first_name' | t }}</label>
-      <input type="text" name="customer[first_name]" id="FirstName" placeholder="{{ 'customer.register.first_name' | t }}" {% if form.first_name %}value="{{ form.first_name }}"{% endif %} autocapitalize="words" autofocus>
+        <label for="FirstName" class="label--hidden">{{ 'customer.register.first_name' | t }}</label>
+        <input type="text" name="customer[first_name]" id="FirstName" class="input-full" placeholder="{{ 'customer.register.first_name' | t }}" {% if form.first_name %}value="{{ form.first_name }}"{% endif %} autocapitalize="words" autofocus>
 
-      <label for="LastName" class="label--hidden">{{ 'customer.register.last_name' | t }}</label>
-      <input type="text" name="customer[last_name]" id="LastName" placeholder="{{ 'customer.register.last_name' | t }}" {% if form.last_name %}value="{{ form.last_name }}"{% endif %} autocapitalize="words">
+        <label for="LastName" class="label--hidden">{{ 'customer.register.last_name' | t }}</label>
+        <input type="text" name="customer[last_name]" id="LastName" class="input-full" placeholder="{{ 'customer.register.last_name' | t }}" {% if form.last_name %}value="{{ form.last_name }}"{% endif %} autocapitalize="words">
 
-      <label for="Email" class="label--hidden">{{ 'customer.register.email' | t }}</label>
-      <input type="email" name="customer[email]" id="Email" placeholder="{{ 'customer.register.email' | t }}" {% if form.errors contains "email" %} class="error"{% elsif form.email %} value="{{ form.email }}"{% endif %} autocorrect="off" autocapitalize="off">
+        <label for="Email" class="label--hidden">{{ 'customer.register.email' | t }}</label>
+        <input type="email" name="customer[email]" id="Email" class="input-full{% if form.errors contains 'email' %} error{% endif %}" placeholder="{{ 'customer.register.email' | t }}" {% if form.email %} value="{{ form.email }}"{% endif %} autocorrect="off" autocapitalize="off">
 
-      <label for="CreatePassword" class="label--hidden">{{ 'customer.register.password' | t }}</label>
-      <input type="password" name="customer[password]" id="CreatePassword" placeholder="{{ 'customer.register.password' | t }}" {% if form.errors contains "password" %} class="error"{% endif %}>
+        <label for="CreatePassword" class="label--hidden">{{ 'customer.register.password' | t }}</label>
+        <input type="password" name="customer[password]" id="CreatePassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.register.password' | t }}">
 
-      <p>
-        <input type="submit" value="{{ 'customer.register.submit' | t }}" class="btn">
-      </p>
-      <a href="{{ shop.url }}">{{ 'customer.register.cancel' | t }}</a>
+        <p>
+          <input type="submit" value="{{ 'customer.register.submit' | t }}" class="btn btn--full">
+        </p>
+        <a href="{{ shop.url }}">{{ 'customer.register.cancel' | t }}</a>
 
-    {% endform %}
+      {% endform %}
+    </div>
 
   </div>
 

--- a/templates/customers/reset_password.liquid
+++ b/templates/customers/reset_password.liquid
@@ -4,25 +4,27 @@
 <div class="grid">
   <div class="grid__item large--one-third push--large--one-third">
 
-    {% form 'reset_customer_password' %}
+    <div class="form-vertical">
+      {% form 'reset_customer_password' %}
 
-      <h1>{{ 'customer.reset_password.title' | t }}</h1>
+        <h1>{{ 'customer.reset_password.title' | t }}</h1>
 
-      <p>{{ 'customer.reset_password.subtext' | t: email: email }}</p>
+        <p>{{ 'customer.reset_password.subtext' | t: email: email }}</p>
 
-      {{ form.errors | default_errors }}
+        {{ form.errors | default_errors }}
 
-      <label for="ResetPassword" class="label--hidden">{{ 'customer.reset_password.password' | t }}</label>
-      <input type="password" value="" name="customer[password]" id="ResetPassword" placeholder="{{ 'customer.reset_password.password' | t }}" {% if form.errors contains "password" %} class="error"{% endif %}>
+        <label for="ResetPassword" class="label--hidden">{{ 'customer.reset_password.password' | t }}</label>
+        <input type="password" value="" name="customer[password]" id="ResetPassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.reset_password.password' | t }}">
 
-      <label for="PasswordConfirmation" class="label--hidden">{{ 'customer.reset_password.password_confirm' | t }}</label>
-      <input type="password" value="" name="customer[password_confirmation]" id="PasswordConfirmation" placeholder="{{ 'customer.reset_password.password_confirm' | t }}" {% if form.errors contains "password_confirmation" %} class="error"{% endif %}>
+        <label for="PasswordConfirmation" class="label--hidden">{{ 'customer.reset_password.password_confirm' | t }}</label>
+        <input type="password" value="" name="customer[password_confirmation]" id="PasswordConfirmation" class="input-full{% if form.errors contains 'password_confirmation' %} error{% endif %}" placeholder="{{ 'customer.reset_password.password_confirm' | t }}">
 
-      <div class="text-center">
-        <input type="submit" class="btn" value="{{ 'customer.reset_password.submit' | t }}">
-      </div>
+        <div class="text-center">
+          <input type="submit" class="btn btn--full" value="{{ 'customer.reset_password.submit' | t }}">
+        </div>
 
-    {% endform %}
+      {% endform %}
+    </div>
 
   </div>
 </div>

--- a/templates/page.contact.liquid
+++ b/templates/page.contact.liquid
@@ -25,7 +25,7 @@
     {% comment %}
       Contact form starts here
     {% endcomment %}
-    <div>
+    <div class="form-vertical">
       {% form 'contact' %}
 
         {% comment %}
@@ -41,17 +41,17 @@
 
         {% assign name_attr = 'contact.form.name' | t | handle %}
         <label for="ContactFormName" class="label--hidden">{{ 'contact.form.name' | t }}</label>
-        <input type="text" id="ContactFormName" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.name' | t }}" autocapitalize="words" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.name }}{% endif %}">
+        <input type="text" id="ContactFormName" class="input-full" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.name' | t }}" autocapitalize="words" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.name }}{% endif %}">
 
         <label for="ContactFormEmail" class="label--hidden">{{ 'contact.form.email' | t }}</label>
-        <input type="email" id="ContactFormEmail" name="contact[email]" placeholder="{{ 'contact.form.email' | t }}" autocorrect="off" autocapitalize="off" value="{% if form.email %}{{ form.email }}{% elsif customer %}{{ customer.email }}{% endif %}">
+        <input type="email" id="ContactFormEmail" class="input-full" name="contact[email]" placeholder="{{ 'contact.form.email' | t }}" autocorrect="off" autocapitalize="off" value="{% if form.email %}{{ form.email }}{% elsif customer %}{{ customer.email }}{% endif %}">
 
         {% assign name_attr = 'contact.form.phone' | t | handle %}
         <label for="ContactFormPhone" class="label--hidden">{{ 'contact.form.phone' | t }}</label>
-        <input type="tel" id="ContactFormPhone" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.phone' | t }}" pattern="[0-9\-]*" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.phone }}{% endif %}">
+        <input type="tel" id="ContactFormPhone" class="input-full" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.phone' | t }}" pattern="[0-9\-]*" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.phone }}{% endif %}">
 
         <label for="ContactFormMessage" class="label--hidden">{{ 'contact.form.message' | t }}</label>
-        <textarea rows="10" id="ContactFormMessage" name="contact[body]" placeholder="{{ 'contact.form.message' | t }}">{% if form.body %}{{ form.body }}{% endif %}</textarea>
+        <textarea rows="10" id="ContactFormMessage" class="input-full" name="contact[body]" placeholder="{{ 'contact.form.message' | t }}">{% if form.body %}{{ form.body }}{% endif %}</textarea>
 
         <input type="submit" class="btn right" value="{{ 'contact.form.send' | t }}">
 

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -59,7 +59,7 @@
         {% comment %}
           ID addToCartForm is a selector for the ajaxify cart plugin
         {% endcomment %}
-        <form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm">
+        <form action="/cart/add" method="post" enctype="multipart/form-data" id="AddToCartForm" class="form-vertical">
 
           {% comment %}
             Add product variants as a dropdown.


### PR DESCRIPTION
Form selectors:
- The form selectors are too specific right now. Using `input[type="XXXX"]` means a single class won't override it.
- By moving to simply `input`, we can style all inputs the same and override them with classes whe needed.
- `radio` and `checkbox` styles are overwritten on the element level
- `input[type="image"]` is overwritten on the element-level.
  - This comes up with `additional_checkout_buttons` (PayPal especially_

Lists
- Allow list styles to be applied in RTE too

Updated templates:
- Updated various `ul` elements to include `no-bullets` class
- Updated customer templates to make forms vertical, rather than default horizontal

@stevebosworth @mpiotrowicz 