### PR TITLE
Revert to original hidden class name. Add better clipping

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1350,12 +1350,13 @@ select::-ms-expand {
 }
 
 /*================ Form labels ================*/
-.label--hidden {
-  display: inline-block;
+.hidden-label {
+  position: absolute;
   height: 0;
   width: 0;
   margin-bottom: 0;
   overflow: hidden;
+  clip: (1px, 1px, 1px, 1px);
 
   // No placeholders, so force show labels
   .ie9 &,

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -143,15 +143,15 @@
               <div class="grid">
 
                 <div class="grid__item large--one-half">
-                  <label for="CommentAuthor" class="label--hidden">{{ 'blogs.comments.name' | t }}</label>
+                  <label for="CommentAuthor" class="hidden-label">{{ 'blogs.comments.name' | t }}</label>
                   <input {% if form.errors contains "author" %} class="error"{% endif %} type="text" name="comment[author]" placeholder="{{ 'blogs.comments.name' | t }}" id="CommentAuthor" value="{{ form.author }}" autocapitalize="words">
 
-                  <label for="CommentEmail" class="label--hidden">{{ 'blogs.comments.email' | t }}</label>
+                  <label for="CommentEmail" class="hidden-label">{{ 'blogs.comments.email' | t }}</label>
                   <input {% if form.errors contains "email" %} class="error"{% endif %} type="email" name="comment[email]" placeholder="{{ 'blogs.comments.email' | t }}" id="CommentEmail" value="{{ form.email }}" autocorrect="off" autocapitalize="off">
                 </div>
 
                 <div class="grid__item">
-                  <label for="CommentBody" class="label--hidden">{{ 'blogs.comments.message' | t }}</label>
+                  <label for="CommentBody" class="hidden-label">{{ 'blogs.comments.message' | t }}</label>
                   <textarea {% if form.errors contains "body" %} class="error"{% endif %} name="comment[body]" id="CommentBody" placeholder="{{ 'blogs.comments.message' | t }}">{{ form.body }}</textarea>
                 </div>
 

--- a/templates/customers/activate_account.liquid
+++ b/templates/customers/activate_account.liquid
@@ -15,10 +15,10 @@
 
         {{ form.errors | default_errors }}
 
-        <label for="CustomerPassword" class="label--hidden">{{ 'customer.activate_account.password' | t }}</label>
+        <label for="CustomerPassword" class="hidden-label">{{ 'customer.activate_account.password' | t }}</label>
         <input type="password" value="" name="customer[password]" id="CustomerPassword" class="input-full" placeholder="{{ 'customer.activate_account.password' | t }}">
 
-        <label for="CustomerPasswordConfirmation" class="label--hidden">{{ 'customer.activate_account.password_confirm' | t }}</label>
+        <label for="CustomerPasswordConfirmation" class="hidden-label">{{ 'customer.activate_account.password_confirm' | t }}</label>
         <input type="password" value="" name="customer[password_confirmation]" id="CustomerPasswordConfirmation" class="input-full" placeholder="{{ 'customer.activate_account.password_confirm' | t }}">
 
         <div class="text-center">

--- a/templates/customers/login.liquid
+++ b/templates/customers/login.liquid
@@ -21,12 +21,12 @@
 
         {{ form.errors | default_errors }}
 
-        <label for="CustomerEmail" class="label--hidden">{{ 'customer.login.email' | t }}</label>
+        <label for="CustomerEmail" class="hidden-label">{{ 'customer.login.email' | t }}</label>
         <input type="email" name="customer[email]" id="CustomerEmail" class="input-full{% if form.errors contains 'email' %} error{% endif %}" placeholder="{{ 'customer.login.email' | t }}" autocorrect="off" autocapitalize="off" autofocus>
 
         {% if form.password_needed %}
 
-          <label for="CustomerPassword" class="label--hidden">{{ 'customer.login.password' | t }}</label>
+          <label for="CustomerPassword" class="hidden-label">{{ 'customer.login.password' | t }}</label>
           <input type="password" value="" name="customer[password]" id="CustomerPassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.login.password' | t }}">
 
           <p>
@@ -62,7 +62,7 @@
           {% assign resetPassword = true %}
         {% endif %}
 
-        <label for="RecoverEmail" class="label--hidden">{{ 'customer.recover_password.email' | t }}</label>
+        <label for="RecoverEmail" class="hidden-label">{{ 'customer.recover_password.email' | t }}</label>
         <input type="email" value="" name="email" id="RecoverEmail" placeholder="{{ 'customer.recover_password.email' | t }}" autocorrect="off" autocapitalize="off">
 
         <p>

--- a/templates/customers/register.liquid
+++ b/templates/customers/register.liquid
@@ -12,16 +12,16 @@
 
         {{ form.errors | default_errors }}
 
-        <label for="FirstName" class="label--hidden">{{ 'customer.register.first_name' | t }}</label>
+        <label for="FirstName" class="hidden-label">{{ 'customer.register.first_name' | t }}</label>
         <input type="text" name="customer[first_name]" id="FirstName" class="input-full" placeholder="{{ 'customer.register.first_name' | t }}" {% if form.first_name %}value="{{ form.first_name }}"{% endif %} autocapitalize="words" autofocus>
 
-        <label for="LastName" class="label--hidden">{{ 'customer.register.last_name' | t }}</label>
+        <label for="LastName" class="hidden-label">{{ 'customer.register.last_name' | t }}</label>
         <input type="text" name="customer[last_name]" id="LastName" class="input-full" placeholder="{{ 'customer.register.last_name' | t }}" {% if form.last_name %}value="{{ form.last_name }}"{% endif %} autocapitalize="words">
 
-        <label for="Email" class="label--hidden">{{ 'customer.register.email' | t }}</label>
+        <label for="Email" class="hidden-label">{{ 'customer.register.email' | t }}</label>
         <input type="email" name="customer[email]" id="Email" class="input-full{% if form.errors contains 'email' %} error{% endif %}" placeholder="{{ 'customer.register.email' | t }}" {% if form.email %} value="{{ form.email }}"{% endif %} autocorrect="off" autocapitalize="off">
 
-        <label for="CreatePassword" class="label--hidden">{{ 'customer.register.password' | t }}</label>
+        <label for="CreatePassword" class="hidden-label">{{ 'customer.register.password' | t }}</label>
         <input type="password" name="customer[password]" id="CreatePassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.register.password' | t }}">
 
         <p>

--- a/templates/customers/reset_password.liquid
+++ b/templates/customers/reset_password.liquid
@@ -13,10 +13,10 @@
 
         {{ form.errors | default_errors }}
 
-        <label for="ResetPassword" class="label--hidden">{{ 'customer.reset_password.password' | t }}</label>
+        <label for="ResetPassword" class="hidden-label">{{ 'customer.reset_password.password' | t }}</label>
         <input type="password" value="" name="customer[password]" id="ResetPassword" class="input-full{% if form.errors contains 'password' %} error{% endif %}" placeholder="{{ 'customer.reset_password.password' | t }}">
 
-        <label for="PasswordConfirmation" class="label--hidden">{{ 'customer.reset_password.password_confirm' | t }}</label>
+        <label for="PasswordConfirmation" class="hidden-label">{{ 'customer.reset_password.password_confirm' | t }}</label>
         <input type="password" value="" name="customer[password_confirmation]" id="PasswordConfirmation" class="input-full{% if form.errors contains 'password_confirmation' %} error{% endif %}" placeholder="{{ 'customer.reset_password.password_confirm' | t }}">
 
         <div class="text-center">

--- a/templates/page.contact.liquid
+++ b/templates/page.contact.liquid
@@ -40,17 +40,17 @@
         {{ form.errors | default_errors }}
 
         {% assign name_attr = 'contact.form.name' | t | handle %}
-        <label for="ContactFormName" class="label--hidden">{{ 'contact.form.name' | t }}</label>
+        <label for="ContactFormName" class="hidden-label">{{ 'contact.form.name' | t }}</label>
         <input type="text" id="ContactFormName" class="input-full" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.name' | t }}" autocapitalize="words" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.name }}{% endif %}">
 
-        <label for="ContactFormEmail" class="label--hidden">{{ 'contact.form.email' | t }}</label>
+        <label for="ContactFormEmail" class="hidden-label">{{ 'contact.form.email' | t }}</label>
         <input type="email" id="ContactFormEmail" class="input-full" name="contact[email]" placeholder="{{ 'contact.form.email' | t }}" autocorrect="off" autocapitalize="off" value="{% if form.email %}{{ form.email }}{% elsif customer %}{{ customer.email }}{% endif %}">
 
         {% assign name_attr = 'contact.form.phone' | t | handle %}
-        <label for="ContactFormPhone" class="label--hidden">{{ 'contact.form.phone' | t }}</label>
+        <label for="ContactFormPhone" class="hidden-label">{{ 'contact.form.phone' | t }}</label>
         <input type="tel" id="ContactFormPhone" class="input-full" name="contact[{{ name_attr }}]" placeholder="{{ 'contact.form.phone' | t }}" pattern="[0-9\-]*" value="{% if form[name_attr] %}{{ form[name_attr] }}{% elsif customer %}{{ customer.phone }}{% endif %}">
 
-        <label for="ContactFormMessage" class="label--hidden">{{ 'contact.form.message' | t }}</label>
+        <label for="ContactFormMessage" class="hidden-label">{{ 'contact.form.message' | t }}</label>
         <textarea rows="10" id="ContactFormMessage" class="input-full" name="contact[body]" placeholder="{{ 'contact.form.message' | t }}">{% if form.body %}{{ form.body }}{% endif %}</textarea>
 
         <input type="submit" class="btn right" value="{{ 'contact.form.send' | t }}">


### PR DESCRIPTION
Class was changed at some point to `hidden--label`. This reverts it back to `label-hidden`, which is what our docs show.