### PR TITLE
fixed sytax of clip in fallback text

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1472,7 +1472,7 @@ label.error {
   remaining accessible to screen readers (h5bp.com)
 ==============================================================================*/
 .supports-fontface .icon-fallback-text .fallback-text {
-  clip: rect(0 0 0 0);
+  clip: rect(0, 0, 0, 0);
   overflow: hidden;
   position: absolute;
   height: 1px;


### PR DESCRIPTION
@cshold 

Fixes syntax for clip rule to properly support IE8+

https://msdn.microsoft.com/en-us/library/ie/ms530748%28v=vs.85%29.aspx