### PR TITLE
Make the at-query more intuitive for min-max calls

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -217,7 +217,9 @@ $socialIconFontStack: 'icons';
 ==============================================================================*/
 $min: min-width;
 $max: max-width;
-@mixin at-query ($constraint, $viewport1, $viewport2:null) {
+@mixin at-query ($constraint_, $viewport1_, $viewport2_:null) {
+ $constraint: $constraint_; $viewport1:$viewport1_; $viewport2:$viewport2_;
+  @if type-of($constraint_) == number { $viewport1 : $constraint_; $viewport2 : $viewport1_; $constraint : null; }
   @if $constraint == $min {
     @media screen and ($min: $viewport1) {
       @content;


### PR DESCRIPTION
I modified the at-query mixin to make calling values of in-between a little more intuitive. 
Currently if you want to define a media query between two ranges, say small and medium, you'd write:
`@include at-query(null, $small, $medium) { ... }`

I don't like passing in null values and sass is smart enough to figure out whats what. So with this change, 
`@include at-query(null, $small, $medium) { ... }` and `@include at-query( $small, $medium) { ... }` are identical.

if you were used to adding null to do an in-between, it works, but if you wanted a short hand, that works too. 

@carolineschnapp 