### PR TITLE
Remove type and vendor links in collection sidebar

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Produktart",
-      "vendors": "Verkäufer",
       "tags": "Tags"
     },
     "sorting": {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Product Types",
-      "vendors": "Vendors",
       "tags": "Tags"
     },
     "sorting": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Tipos de producto",
-      "vendors": "Proveedores",
       "tags": "Etiquetas"
     },
     "sorting": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Types de produits",
-      "vendors": "Fournisseurs",
       "tags": "Filtres"
     },
     "sorting": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Tipos de produtos",
-      "vendors": "Fabricantes",
       "tags": "Marcadores"
     },
     "sorting": {

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -84,8 +84,6 @@
       }
     },
     "sidebar": {
-      "types": "Tipos de Produtos",
-      "vendors": "Fornecedores",
       "tags": "Etiquetas"
     },
     "sorting": {

--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -11,50 +11,6 @@
 {% endcomment %}
 
 {% comment %}
-  Product types in the current collection
-    - List all of the shop's types with collections.all.all_types
-    - List the current collection's types with collection.all_types
-{% endcomment %}
-{% if collection.all_types.size > 0 %}
-<h3>{{ 'collections.sidebar.types' | t }}</h3>
-  <ul class="no-bullets">
-    {% for type in collection.all_types %}
-      {% if collection.current_type == type %}
-        <li class="filter--active">
-          {{ type }}
-        </li>
-      {% else %}
-        <li>
-          {{ type | link_to_type }}
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{% endif %}
-
-{% comment %}
-  Product vendors in the current collection
-    - List all of the shop's vendors with collections.all.all_vendors
-    - List the current collection's vendors with collection.all_vendors
-{% endcomment %}
-{% if collection.all_vendors.size > 1 %}
-  <h3>{{ 'collections.sidebar.vendors' | t }}</h3>
-  <ul class="no-bullets">
-    {% for vendor in collection.all_vendors %}
-      {% if collection.current_vendor == vendor %}
-        <li class="filter--active">
-          {{ vendor }}
-        </li>
-      {% else %}
-        <li>
-          {{ vendor | link_to_vendor }}
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{% endif %}
-
-{% comment %}
   Product tags in the current collection
 {% endcomment %}
 {% if collection.all_tags.size > 0 %}


### PR DESCRIPTION
@pauldpritchard brought up a good point, listing out `type` and `vendor` in the collection sidebar makes it seem Shopify has the native ability to sort the current content by them. In reality, the links pull you out of the current collection/tag to the top-level type or vendor.

Thoughts? @mpiotrowicz @carolineschnapp @fredryk 