### PR TITLE
Hidden label fix for old ie

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1423,10 +1423,12 @@ select::-ms-expand {
   // No placeholders, so force show labels
   .ie9 &,
   .lt-ie9 & {
+    position: static;
     height: auto;
     width: auto;
     margin-bottom: 2px;
     overflow: visible;
+    clip: initial;
   }
 }
 


### PR DESCRIPTION
Old IE can't use placeholder, so make the invisible labels visible. The absolute positioning was never removed, and the clip is reset.