### PR TITLE
Add i18n for catch-all collection tags

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "Alle {{ collection }}",
       "no_matches": "Es tut uns leid, aber Ihre Suche nach Produkten hat keine Treffer ergeben.",
       "link_title": "Durchsuchen Sie unsere {{ title }}-Zusammenstellung",
       "grid_view": "Gitteransicht",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "All {{ collection }}",
       "no_matches": "Sorry, there are no products in this collection",
       "link_title": "Browse our {{ title }} collection",
       "grid_view": "Grid view",

--- a/locales/es.json
+++ b/locales/es.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "Todo {{ collection }}",
       "no_matches": "Lo sentimos, no hay productos que coincidan con su búsqueda.",
       "link_title": "Navegue por nuestra colección {{ title }}",
       "grid_view": "Tabla",

--- a/locales/es.json
+++ b/locales/es.json
@@ -74,7 +74,7 @@
   },
   "collections": {
     "general": {
-      "all_of_collection": "Todo {{ collection }}",
+      "all_of_collection": "Todos",
       "no_matches": "Lo sentimos, no hay productos que coincidan con su búsqueda.",
       "link_title": "Navegue por nuestra colección {{ title }}",
       "grid_view": "Tabla",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -74,7 +74,7 @@
   },
   "collections": {
     "general": {
-      "all_of_collection": "Tous les {{ collection }}",
+      "all_of_collection": "Tout",
       "no_matches": "Aucun produit ne correspond à votre recherche.",
       "link_title": "Consultez la collection {{ title }}",
       "grid_view": "Grille",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "Tous les {{ collection }}",
       "no_matches": "Aucun produit ne correspond à votre recherche.",
       "link_title": "Consultez la collection {{ title }}",
       "grid_view": "Grille",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "Todos de {{ collection }}",
       "no_matches": "Desculpe, mas não há produtos correspondentes à sua busca.",
       "link_title": "Explore a nossa coleção {{ title }}",
       "grid_view": "Grelha",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -74,6 +74,7 @@
   },
   "collections": {
     "general": {
+      "all_of_collection": "Toda a {{ collection }}",
       "no_matches": "Lamentamos, mas nenhum produto corresponde à sua pesquisa.",
       "link_title": "Explorar a nossa coleção {{ title }}",
       "grid_view": "Grelha",

--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -27,20 +27,25 @@
         Good for /collections/all collection and regular collections
       {% endcomment %}
       {% if collection.handle %}
-        <a href="/collections/{{ collection.handle }}">All {{ collection.title }}</a>
+        <a href="/collections/{{ collection.handle }}">
+          {{ 'collections.general.all_of_collection' | t: collection: collection.title }}
+        </a>
 
       {% comment %}
         Good for automatic type collections
       {% endcomment %}
       {% elsif collection.current_type %}
-        <a href="{{ collection.current_type | url_for_type }}">All {{ collection.title }}</a>
+        <a href="{{ collection.current_type | url_for_type }}">
+          {{ 'collections.general.all_of_collection' | t: collection: collection.title }}
+        </a>
 
       {% comment %}
         Good for automatic vendor collections
       {% endcomment %}
       {% elsif collection.current_vendor %}
-        <a href="{{ collection.current_vendor | url_for_vendor }}">All {{ collection.title }}</a>
-
+        <a href="{{ collection.current_vendor | url_for_vendor }}">
+          {{ 'collections.general.all_of_collection' | t: collection: collection.title }}
+        </a>
       {% endif %}
     </li>
 


### PR DESCRIPTION
Catch-all links to create *All **collection*** links were not i18n friendly. This fixes that.

cc @carolineschnapp 