### PR TITLE
Safer drawer transition implementation

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -2026,19 +2026,17 @@ label.error {
 }
 
 .is-moved-by-drawer {
+  @include transition($drawerTransition);
+
   .js-drawer-open-left & {
     @include transform(translateX($drawerNavWidth));
-    @include transition($drawerTransition);
+
   }
 
   .js-drawer-open-right & {
     @include transform(translateX(-$drawerCartWidth));
     @include transition($drawerTransition);
   }
-}
-
-.is-moved-by-drawer.is-transitioning {
-  @include transition($drawerTransition);
 }
 
 .drawer__header {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -2030,12 +2030,10 @@ label.error {
 
   .js-drawer-open-left & {
     @include transform(translateX($drawerNavWidth));
-
   }
 
   .js-drawer-open-right & {
     @include transform(translateX(-$drawerCartWidth));
-    @include transition($drawerTransition);
   }
 }
 


### PR DESCRIPTION
Since `.is-transitioning` is added/removed to `.is-moved-by-drawer`, the transition sometimes is removed from the element at the wrong time. This adds the transition to the root element, making sure the animation never gets choppy.

cc @stevebosworth 