### PR TITLE
Fix broken edit/delete buttons on address template with pagination

### DIFF
--- a/templates/customers/addresses.liquid
+++ b/templates/customers/addresses.liquid
@@ -232,6 +232,6 @@
       }
     }
   }
-  </script>
+</script>
 
 {% endpaginate %}

--- a/templates/customers/addresses.liquid
+++ b/templates/customers/addresses.liquid
@@ -102,99 +102,98 @@
       List all customer addresses with a unique edit form.
       Also add pagination in case they have a large number of addresses
     {% endcomment %}
+    {% for address in customer.addresses %}
 
-      {% for address in customer.addresses %}
+      <h3>
+        {{ address.first_name | capitalize }} {{ address.last_name | capitalize }}
+        {% if address == customer.default_address %}({{ 'customer.addresses.default' | t }}){% endif %}
+      </h3>
 
-        <h3>
-          {{ address.first_name | capitalize }} {{ address.last_name | capitalize }}
-          {% if address == customer.default_address %}({{ 'customer.addresses.default' | t }}){% endif %}
-        </h3>
+      <p>
+        {{ address.company }}<br>
+        {{ address.street }}<br>
+        {{ address.city | capitalize }}<br>
+        {% if address.province_code %}
+          {{ address.province_code | upcase }}<br>
+        {% endif %}
+        {{ address.zip | upcase }}<br>
+        {{ address.country }}<br>
+        {{ address.phone }}
+      </p>
+      <p>
+        {{ 'customer.addresses.edit' | t | edit_customer_address_link: address.id }} |
+        {{ 'customer.addresses.delete' | t | delete_customer_address_link: address.id }}
+      </p>
 
-        <p>
-          {{ address.company }}<br>
-          {{ address.street }}<br>
-          {{ address.city | capitalize }}<br>
-          {% if address.province_code %}
-            {{ address.province_code | upcase }}<br>
-          {% endif %}
-          {{ address.zip | upcase }}<br>
-          {{ address.country }}<br>
-          {{ address.phone }}
-        </p>
-        <p>
-          {{ 'customer.addresses.edit' | t | edit_customer_address_link: address.id }} |
-          {{ 'customer.addresses.delete' | t | delete_customer_address_link: address.id }}
-        </p>
+      <div id="EditAddress_{{ address.id }}" class="form-vertical" style="display:none;">
+        {% form 'customer_address', address %}
 
-        <div id="EditAddress_{{ address.id }}" class="form-vertical" style="display:none;">
-          {% form 'customer_address', address %}
+          <h4>{{ 'customer.addresses.edit_address' | t }}</h4>
 
-            <h4>{{ 'customer.addresses.edit_address' | t }}</h4>
-
-            <div class="grid">
-              <div class="grid__item one-half small--one-whole">
-                <label for="AddressFirstName_{{ form.id }}">{{ 'customer.addresses.first_name' | t }}</label>
-                <input type="text" id="AddressFirstName_{{ form.id }}" class="input-full" name="address[first_name]" value="{{ form.first_name }}" autocapitalize="words">
-              </div>
-
-              <div class="grid__item one-half small--one-whole">
-                <label for="AddressLastName_{{ form.id }}">{{ 'customer.addresses.last_name' | t }}</label>
-                <input type="text" id="AddressLastName_{{ form.id }}" class="input-full" name="address[last_name]" value="{{ form.last_name }}" autocapitalize="words">
-              </div>
+          <div class="grid">
+            <div class="grid__item one-half small--one-whole">
+              <label for="AddressFirstName_{{ form.id }}">{{ 'customer.addresses.first_name' | t }}</label>
+              <input type="text" id="AddressFirstName_{{ form.id }}" class="input-full" name="address[first_name]" value="{{ form.first_name }}" autocapitalize="words">
             </div>
 
-            <label for="AddressCompany_{{ form.id }}">{{ 'customer.addresses.company' | t }}</label>
-            <input type="text" id="AddressCompany_{{ form.id }}" class="input-full" name="address[company]" value="{{ form.company }}" autocapitalize="words">
+            <div class="grid__item one-half small--one-whole">
+              <label for="AddressLastName_{{ form.id }}">{{ 'customer.addresses.last_name' | t }}</label>
+              <input type="text" id="AddressLastName_{{ form.id }}" class="input-full" name="address[last_name]" value="{{ form.last_name }}" autocapitalize="words">
+            </div>
+          </div>
 
-            <label for="AddressAddress1_{{ form.id }}">{{ 'customer.addresses.address1' | t }}</label>
-            <input type="text" id="AddressAddress1_{{ form.id }}" class="input-full" name="address[address1]" value="{{ form.address1 }}" autocapitalize="words">
+          <label for="AddressCompany_{{ form.id }}">{{ 'customer.addresses.company' | t }}</label>
+          <input type="text" id="AddressCompany_{{ form.id }}" class="input-full" name="address[company]" value="{{ form.company }}" autocapitalize="words">
 
-            <label for="AddressAddress2_{{ form.id }}">{{ 'customer.addresses.address2' | t }}</label>
-            <input type="text" id="AddressAddress2_{{ form.id }}" class="input-full" name="address[address2]" value="{{ form.address2 }}" autocapitalize="words">
+          <label for="AddressAddress1_{{ form.id }}">{{ 'customer.addresses.address1' | t }}</label>
+          <input type="text" id="AddressAddress1_{{ form.id }}" class="input-full" name="address[address1]" value="{{ form.address1 }}" autocapitalize="words">
 
-            <label for="AddressCity_{{ form.id }}">{{ 'customer.addresses.city' | t }}</label>
-            <input type="text" id="AddressCity_{{ form.id }}" class="input-full" name="address[city]" value="{{ form.city }}" autocapitalize="words">
+          <label for="AddressAddress2_{{ form.id }}">{{ 'customer.addresses.address2' | t }}</label>
+          <input type="text" id="AddressAddress2_{{ form.id }}" class="input-full" name="address[address2]" value="{{ form.address2 }}" autocapitalize="words">
 
-            <label for="AddressCountry_{{ form.id }}">{{ 'customer.addresses.country' | t }}</label>
-            <select id="AddressCountry_{{ form.id }}" class="input-full" name="address[country]" data-default="{{ form.country }}">{{ country_option_tags }}</select>
+          <label for="AddressCity_{{ form.id }}">{{ 'customer.addresses.city' | t }}</label>
+          <input type="text" id="AddressCity_{{ form.id }}" class="input-full" name="address[city]" value="{{ form.city }}" autocapitalize="words">
 
-            <div id="AddressProvinceContainer_{{ form.id }}" style="display:none">
-              <label for="AddressProvince_{{ form.id }}">{{ 'customer.addresses.province' | t }}</label>
-              <select id="AddressProvince_{{ form.id }}" class="input-full" name="address[province]" data-default="{{ form.province }}"></select>
+          <label for="AddressCountry_{{ form.id }}">{{ 'customer.addresses.country' | t }}</label>
+          <select id="AddressCountry_{{ form.id }}" class="input-full" name="address[country]" data-default="{{ form.country }}">{{ country_option_tags }}</select>
+
+          <div id="AddressProvinceContainer_{{ form.id }}" style="display:none">
+            <label for="AddressProvince_{{ form.id }}">{{ 'customer.addresses.province' | t }}</label>
+            <select id="AddressProvince_{{ form.id }}" class="input-full" name="address[province]" data-default="{{ form.province }}"></select>
+          </div>
+
+          <div class="grid">
+            <div class="grid__item one-half small--one-whole">
+              <label for="AddressZip_{{ form.id }}">{{ 'customer.addresses.zip' | t }}</label>
+              <input type="text" id="AddressZip_{{ form.id }}" class="input-full" name="address[zip]" value="{{ form.zip }}" autocapitalize="characters">
             </div>
 
-            <div class="grid">
-              <div class="grid__item one-half small--one-whole">
-                <label for="AddressZip_{{ form.id }}">{{ 'customer.addresses.zip' | t }}</label>
-                <input type="text" id="AddressZip_{{ form.id }}" class="input-full" name="address[zip]" value="{{ form.zip }}" autocapitalize="characters">
-              </div>
-
-              <div class="grid__item one-half small--one-whole">
-                <label for="AddressPhone_{{ form.id }}">{{ 'customer.addresses.phone' | t }}</label>
-                <input type="tel" id="AddressPhone_{{ form.id }}" class="input-full" name="address[phone]" value="{{ form.phone }}">
-              </div>
+            <div class="grid__item one-half small--one-whole">
+              <label for="AddressPhone_{{ form.id }}">{{ 'customer.addresses.phone' | t }}</label>
+              <input type="tel" id="AddressPhone_{{ form.id }}" class="input-full" name="address[phone]" value="{{ form.phone }}">
             </div>
+          </div>
 
-            <p>
-              {{ form.set_as_default_checkbox }}
-              <label for="address_default_address_{{ form.id }}" class="inline">{{ 'customer.addresses.set_default' | t }}</label>
-            </p>
+          <p>
+            {{ form.set_as_default_checkbox }}
+            <label for="address_default_address_{{ form.id }}" class="inline">{{ 'customer.addresses.set_default' | t }}</label>
+          </p>
 
-            <p><input type="submit" class="btn" value="{{ 'customer.addresses.update' | t }}"></p>
-            <p><a href="#" onclick="Shopify.CustomerAddress.toggleForm({{ form.id }}); return false;">{{ 'customer.addresses.cancel' | t }}</a></p>
+          <p><input type="submit" class="btn" value="{{ 'customer.addresses.update' | t }}"></p>
+          <p><a href="#" onclick="Shopify.CustomerAddress.toggleForm({{ form.id }}); return false;">{{ 'customer.addresses.cancel' | t }}</a></p>
 
-            <hr>
-          {% endform %}
-        </div>
+          <hr>
+        {% endform %}
+      </div>
 
-      {% endfor %}
+    {% endfor %}
 
-      {% if paginate.pages > 1 %}
-        <hr>
-        <div class="pagination">
-          {{ paginate | default_pagination | replace: '&laquo; Previous', '&larr;' | replace: 'Next &raquo;', '&rarr;' }}
-        </div>
-      {% endif %}
+    {% if paginate.pages > 1 %}
+      <hr>
+      <div class="pagination">
+        {{ paginate | default_pagination | replace: '&laquo; Previous', '&larr;' | replace: 'Next &raquo;', '&rarr;' }}
+      </div>
+    {% endif %}
   </div>
 
 </div>

--- a/templates/customers/addresses.liquid
+++ b/templates/customers/addresses.liquid
@@ -8,6 +8,8 @@
 
 {% endcomment %}
 
+{% paginate customer.addresses by 5 %}
+
 <header class="section-header">
   <h1 class="section-header__left">{{ 'customer.account.title' | t }}</h1>
   <div class="section-header__right">
@@ -100,7 +102,7 @@
       List all customer addresses with a unique edit form.
       Also add pagination in case they have a large number of addresses
     {% endcomment %}
-    {% paginate customer.addresses by 5 %}
+
       {% for address in customer.addresses %}
 
         <h3>
@@ -193,8 +195,6 @@
           {{ paginate | default_pagination | replace: '&laquo; Previous', '&larr;' | replace: 'Next &raquo;', '&rarr;' }}
         </div>
       {% endif %}
-
-    {% endpaginate %}
   </div>
 
 </div>
@@ -232,4 +232,6 @@
       }
     }
   }
-</script>
+  </script>
+
+{% endpaginate %}


### PR DESCRIPTION
Fixes #385

Instead of using multiple `paginate` tags as the issue suggests (which also works), this wraps the entire template in the paginate tags to solve the same issue.

cc @stevebosworth @schaeken 