### PR TITLE
i18n for varying price label

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Vorheriger Artikel",
       "next_product_html": "Nächster Artikel &rarr;",
-      "from": "Von"
+      "from_text_html": "Von {{ price }}"
     },
     "product": {
       "sold_out": "Ausverkauft",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Previous Product",
       "next_product_html": "Next Product &rarr;",
-      "from": "From"
+      "from_text_html": "From {{ price }}"
     },
     "product": {
       "sold_out": "Sold Out",

--- a/locales/es.json
+++ b/locales/es.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Producto anterior",
       "next_product_html": "Siguiente producto &rarr;",
-      "from": "De"
+      "from_text_html": "De {{ price }}"
     },
     "product": {
       "sold_out": "Agotado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Produit précédent",
       "next_product_html": "Produit suivant &rarr;",
-      "from": "À partir de"
+      "from_text_html": "À partir de {{ price }}"
     },
     "product": {
       "sold_out": "Épuisé",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Produto anterior",
       "next_product_html": "Próximo produto &rarr;",
-      "from": "A partir de"
+      "from_text_html": "A partir de {{ price }}"
     },
     "product": {
       "sold_out": "Esgotado",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -263,7 +263,7 @@
     "general": {
       "previous_product_html": "&larr; Produto Anterior",
       "next_product_html": "Produto Seguinte &rarr;",
-      "from": "Desde"
+      "from_text_html": "Desde {{ price }}"
     },
     "product": {
       "sold_out": "Esgotado",

--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -72,8 +72,12 @@
         {{ product.price | money }}
       {% endif %}
     {% else %}
-      {% if product.price_varies %}{{ 'products.general.from' | t }}{% endif %}
-      {{ product.price | money }}
+      {% if product.price_varies %}
+        {% assign price = product.price | money %}
+        {{ 'products.general.from_text_html' | t: price: price }}
+      {% else %}
+        {{ product.price | money }}
+      {% endif %}
     {% endif %}
     {% if sold_out %}
       <br><strong>{{ 'products.product.sold_out' | t }}</strong>

--- a/snippets/social-meta-tags.liquid
+++ b/snippets/social-meta-tags.liquid
@@ -74,7 +74,8 @@
   <meta name="twitter:image:width" content="240">
   <meta name="twitter:image:height" content="240">
   <meta name="twitter:label1" content="Price">
-  <meta name="twitter:data1" content="{% if product.price_varies %}From {% endif %}{{ product.price | money_with_currency | strip_html | escape }}">
+  {% assign price = product.price | money_with_currency | strip_html | escape %}
+  <meta name="twitter:data1" content="{% if product.price_varies %}{{ 'products.general.from_text_html' | t: price: price }}{% else %}{{ price }}{% endif %}">
   {% if product.vendor != blank %}
   <meta name="twitter:label2" content="Brand">
   <meta name="twitter:data2" content="{{ product.vendor | escape }}">

--- a/templates/collection.list.liquid
+++ b/templates/collection.list.liquid
@@ -116,8 +116,12 @@
                       {{ product.price | money }}
                     {% endif %}
                   {% else %}
-                    {% if product.price_varies %}{{ 'products.general.from' | t }}{% endif %}
-                    {{ product.price | money }}
+                    {% if product.price_varies %}
+                      {% assign price = product.price | money %}
+                      {{ 'products.general.from_text_html' | t: price: price }}
+                    {% else %}
+                      {{ product.price | money }}
+                    {% endif %}
                   {% endif %}
                   {% if sold_out %}
                     <br><strong>{{ 'products.product.sold_out' | t }}</strong>

--- a/templates/search.liquid
+++ b/templates/search.liquid
@@ -98,8 +98,12 @@
                             <span itemprop="price">{{ item.price | money }}</span>
                           {% endif %}
                         {% else %}
-                          {% if item.price_varies %}{{ 'products.general.from' | t }}{% endif %}
-                          <span itemprop="price">{{ item.price | money }}</span>
+                          {% if item.price_varies %}
+                            {% assign price = item.price | money %}
+                            <span itemprop="price">{{ 'products.general.from_text_html' | t: price: price }}</span>
+                          {% else %}
+                            <span itemprop="price">{{ item.price | money }}</span>
+                          {% endif %}
                         {% endif %}
                         {% if sold_out %}
                           <br><strong>{{ 'products.product.sold_out' | t }}</strong>
@@ -141,8 +145,12 @@
                         <span itemprop="price">{{ item.price | money }}</span>
                       {% endif %}
                     {% else %}
-                      {% if item.price_varies %}{{ 'products.general.from' | t }}{% endif %}
-                      <span itemprop="price">{{ item.price | money }}</span>
+                      {% if item.price_varies %}
+                        {% assign price = item.price | money %}
+                        <span itemprop="price">{{ 'products.general.from_text_html' | t: price: price }}</span>
+                      {% else %}
+                        <span itemprop="price">{{ item.price | money }}</span>
+                      {% endif %}
                     {% endif %}
                     {% if sold_out %}
                       <br><strong>{{ 'products.product.sold_out' | t }}</strong>


### PR DESCRIPTION
Following on the work by @schaeken in https://github.com/Shopify/shopify-themes/pull/1259, using i18n-friendly translations for **From $xx.xx**.

This covers the Twitter card meta data, product grid items, and search results (grid and list views).

@stevebosworth @mpiotrowicz 