### PR TITLE
Fixed broken clip property

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1418,7 +1418,7 @@ select::-ms-expand {
   width: 0;
   margin-bottom: 0;
   overflow: hidden;
-  clip: (1px, 1px, 1px, 1px);
+  clip: rect(1px, 1px, 1px, 1px);
 
   // No placeholders, so force show labels
   .ie9 &,


### PR DESCRIPTION
`rect` wasn't there, so `clip` didn't work at all.