### PR TITLE
Use text color rather than border for select element

### DIFF
--- a/assets/ico-select.svg.liquid
+++ b/assets/ico-select.svg.liquid
@@ -3,6 +3,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
    width="8px" height="5px" viewBox="0 0 8 5" enable-background="new 0 0 8 5" xml:space="preserve">
-<path fill="{{settings.color_borders}}" d="M0,0c0,0,3.4,4.4,3.5,4.4C3.7,4.4,7.1,0,7.1,0H0z"/>
+<path fill="{{settings.color_body_text}}" d="M0,0c0,0,3.4,4.4,3.5,4.4C3.7,4.4,7.1,0,7.1,0H0z"/>
 </svg>
 


### PR DESCRIPTION
Use the text rather than border color for the custom select arrow.

cc/ @carolineschnapp @stevebosworth 