### PR TITLE
Link against cdnjs instead of googlecode for html5shiv

### DIFF
--- a/snippets/oldIE-js.liquid
+++ b/snippets/oldIE-js.liquid
@@ -7,7 +7,7 @@
 {% endcomment %}
 {% assign respond_js_secret_key = shop.domain | md5 %}
 <!--[if lt IE 9]>
-{{ '//html5shiv.googlecode.com/svn/trunk/html5.js' | script_tag }}
+{{ '//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js' | script_tag }}
 {{ 'respond.min.js' | asset_url | script_tag }}
 <link href="{{ 'respond-proxy.html' | asset_url | split: '?' | first }}" id="respond-proxy" rel="respond-proxy" />
 <link href="//{{ shop.domain }}/search?q={{ respond_js_secret_key }}" id="respond-redirect" rel="respond-redirect" />


### PR DESCRIPTION
Linking against Google Code is problematic because
- The version is not pinned
- Google Code is being shut down
- The `/svn` endpoint was probably not intended to be a CDN