### PR TITLE
Let ajax cart submit as normal form with proper quantity

### DIFF
--- a/snippets/ajax-cart-template.liquid
+++ b/snippets/ajax-cart-template.liquid
@@ -77,7 +77,7 @@
   {% raw %}
     <div class="ajaxcart__qty">
       <button type="button" class="ajaxcart__qty-adjust ajaxcart__qty--minus" data-id="{{id}}" data-qty="{{itemMinus}}">&minus;</button>
-      <input type="text" class="ajaxcart__qty-num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity" pattern="[0-9]*">
+      <input type="text" name="updates[]" class="ajaxcart__qty-num" value="{{itemQty}}" min="0" data-id="{{id}}" aria-label="quantity" pattern="[0-9]*">
       <button type="button" class="ajaxcart__qty-adjust ajaxcart__qty--plus" data-id="{{id}}" data-qty="{{itemAdd}}">+</button>
     </div>
   {% endraw %}


### PR DESCRIPTION
Allow the ajax cart to submit as a normal form even if the ajax is unable to update the cart fast enough. This happens if you change the product quantity in the cart and press enter to submit the form. 