### PR TITLE
Prefix mixins cleanup

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -178,6 +178,24 @@ $socialIconFontStack: 'icons';
   *zoom: 1;
 }
 
+/*
+  Bourbon-inspired prefixer mixin for generating vendor prefixes.
+
+  Usage:
+
+    .element {
+      @include prefixer(transform, scale(1), ms webkit spec);
+    }
+
+  Output:
+
+    .element {
+      -ms-transform: scale(1);
+      -webkit-transform: scale(1);
+      transform: scale(1);
+    }
+*/
+
 @mixin prefixer($property, $value, $prefixes) {
   @each $prefix in $prefixes {
     @if $prefix == webkit {
@@ -202,6 +220,10 @@ $socialIconFontStack: 'icons';
 
 @mixin user-select($value) {
   @include prefixer(user-select, $value, webkit moz ms spec);
+}
+
+@mixin backface($visibility: hidden) {
+  @include prefixer(backface-visiblity, $visibility, webkit spec);
 }
 
 @function em($target, $context: $baseFontSize) {
@@ -1925,7 +1947,7 @@ label.error {
   visibility: hidden;
   overflow: hidden;
   transition: all 300ms cubic-bezier(0.57, 0.06, 0.05, 0.95);
-  @include prefixer(backface-visiblity, hidden, webkit spec);
+  @include backface();
 
   .mobile-nav--expanded + & {
     visibility: visible;
@@ -2306,7 +2328,7 @@ label.error {
     overflow: hidden;
     visibility: hidden;
     transition: all 450ms cubic-bezier(0.57,.06,.05,.95);
-    @include prefixer(backface-visiblity, hidden, webkit spec);
+    @include backface();
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -1949,11 +1949,9 @@ label.error {
 ==============================================================================*/
 .js-drawer-open {
   overflow: hidden;
-  height: 100%;
 }
 
 .drawer {
-  will-change: transform;
   display: none;
   position: fixed;
   overflow-y: auto;
@@ -2018,7 +2016,6 @@ label.error {
 }
 
 .is-moved-by-drawer {
-  will-change: transform;
   transition: $drawerTransition;
 
   .js-drawer-open-left & {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -197,7 +197,7 @@ $socialIconFontStack: 'icons';
 }
 
 @mixin transform($transform: 0.1s all) {
-  @include prefixer(transform, $transform, webkit spec);
+  @include prefixer(transform, $transform, ms webkit spec);
 }
 
 @mixin user-select($value) {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -126,7 +126,7 @@ $drawerCartWidth: 300px;
 $colorDrawers: #f6f6f6;
 $colorDrawerBorder: darken($colorDrawers, 5%);
 $colorDrawerText: #333;
-$drawerTransition: 'all 0.4s cubic-bezier(0.46, 0.01, 0.32, 1)';
+$drawerTransition: all 0.4s cubic-bezier(0.46, 0.01, 0.32, 1);
 
 // Sizing variables
 $siteWidth: 1180px;
@@ -1949,9 +1949,11 @@ label.error {
 ==============================================================================*/
 .js-drawer-open {
   overflow: hidden;
+  height: 100%;
 }
 
 .drawer {
+  will-change: transform;
   display: none;
   position: fixed;
   overflow-y: auto;
@@ -2016,6 +2018,7 @@ label.error {
 }
 
 .is-moved-by-drawer {
+  will-change: transform;
   transition: $drawerTransition;
 
   .js-drawer-open-left & {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -200,6 +200,10 @@ $socialIconFontStack: 'icons';
   @include prefixer(transform, $transform, webkit spec);
 }
 
+@mixin user-select($value) {
+  @include prefixer(user-select, $value, webkit moz ms spec);
+}
+
 @function em($target, $context: $baseFontSize) {
   @if $target == 0 {
     @return 0;
@@ -1047,7 +1051,7 @@ html input[disabled] {
   white-space: nowrap;
   cursor: pointer;
   border: 1px solid transparent;
-  @include prefix('user-select', 'none');
+  @include user-select(none);
   -webkit-appearance: none;
   -moz-appearance: none;
   border-radius: $radius;
@@ -1264,7 +1268,7 @@ button,
 select {
   padding: 0;
   margin: 0;
-  @include prefix('user-select', 'text');
+  @include user-select(text);
 }
 
 button {
@@ -1583,7 +1587,7 @@ label.error {
 .icon-youtube:before { content: "\79"; }
 
 .payment-icons {
-  @include prefix('user-select', 'none');
+  @include user-select(none);
   cursor: default;
 
   li {
@@ -2362,7 +2366,7 @@ label.error {
   background: none;
   text-align: center;
   overflow: hidden;
-  @include prefix('user-select', 'none');
+  @include user-select(none);
 
   &:hover,
   &:focus {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -178,23 +178,23 @@ $socialIconFontStack: 'icons';
   *zoom: 1;
 }
 
-/*
-  Bourbon-inspired prefixer mixin for generating vendor prefixes.
+/*============================================================================
+  Prefixer mixin for generating vendor prefixes:
+    - Based on https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/addons/_prefixer.scss
+    - Usage:
 
-  Usage:
+      // Input:
+      .element {
+        @include prefixer(transform, scale(1), ms webkit spec);
+      }
 
-    .element {
-      @include prefixer(transform, scale(1), ms webkit spec);
-    }
-
-  Output:
-
-    .element {
-      -ms-transform: scale(1);
-      -webkit-transform: scale(1);
-      transform: scale(1);
-    }
-*/
+      // Output:
+      .element {
+        -ms-transform: scale(1);
+        -webkit-transform: scale(1);
+        transform: scale(1);
+      }
+==============================================================================*/
 
 @mixin prefixer($property, $value, $prefixes) {
   @each $prefix in $prefixes {

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -178,26 +178,26 @@ $socialIconFontStack: 'icons';
   *zoom: 1;
 }
 
-@mixin prefix($property, $value) {
-  -webkit-#{$property}: #{$value};
-  -moz-#{$property}: #{$value};
-  -ms-#{$property}: #{$value};
-  -o-#{$property}: #{$value};
-  #{$property}: #{$value};
+@mixin prefixer($property, $value, $prefixes) {
+  @each $prefix in $prefixes {
+    @if $prefix == webkit {
+      -webkit-#{$property}: $value;
+    } @else if $prefix == moz {
+      -moz-#{$property}: $value;
+    } @else if $prefix == ms {
+      -ms-#{$property}: $value;
+    } @else if $prefix == o {
+      -o-#{$property}: $value;
+    } @else if $prefix == spec {
+      #{$property}: $value;
+    } @else  {
+      @warn "Unrecognized prefix: #{$prefix}";
+    }
+  }
 }
 
 @mixin transform($transform: 0.1s all) {
-  @include prefix('transform', #{$transform});
-}
-
-@mixin backface($visibility: hidden) {
-  @include prefix('backface-visibility', #{$visibility});
-}
-
-@mixin box-sizing($box-sizing: border-box) {
-  -webkit-box-sizing: #{$box-sizing};
-  -moz-box-sizing: #{$box-sizing};
-  box-sizing: #{$box-sizing};
+  @include prefixer(transform, $transform, webkit spec);
 }
 
 @function em($target, $context: $baseFontSize) {
@@ -247,7 +247,7 @@ $max: max-width;
   #Normalize
 ==============================================================================*/
 *, input, :before, :after {
-  @include box-sizing();
+  box-sizing: border-box;
 }
 
 html, body {
@@ -350,6 +350,7 @@ $class-type: unquote(".");
 }
 
 #{$class-type}grid__item {
+  box-sizing: border-box;
   float: left;
   min-height: 1px;
   padding-left: $gridGutter;
@@ -357,7 +358,6 @@ $class-type: unquote(".");
   @if $mobile-first == true {
     width: 100%;
   }
-  @include box-sizing();
 }
 
 /*============================================================================
@@ -1921,7 +1921,7 @@ label.error {
   visibility: hidden;
   overflow: hidden;
   transition: all 300ms cubic-bezier(0.57, 0.06, 0.05, 0.95);
-  @include backface(hidden);
+  @include prefixer(backface-visiblity, hidden, webkit spec);
 
   .mobile-nav--expanded + & {
     visibility: visible;
@@ -2302,7 +2302,7 @@ label.error {
     overflow: hidden;
     visibility: hidden;
     transition: all 450ms cubic-bezier(0.57,.06,.05,.95);
-    @include backface(hidden);
+    @include prefixer(backface-visiblity, hidden, webkit spec);
   }
 }
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -190,16 +190,6 @@ $socialIconFontStack: 'icons';
   @include prefix('transform', #{$transform});
 }
 
-@mixin gradient($from, $to, $fallback) {
-  background: $fallback;
-  background: -moz-linear-gradient(top, $from 0%, $to 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,$from), color-stop(100%,$to));
-  background: -webkit-linear-gradient(top, $from 0%, $to 100%);
-  background: -o-linear-gradient(top, $from 0%, $to 100%);
-  background: -ms-linear-gradient(top, $from 0%, $to 100%);
-  background: linear-gradient(top bottom, $from 0%, $to 100%);
-}
-
 @mixin backface($visibility: hidden) {
   @include prefix('backface-visibility', #{$visibility});
 }

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -186,10 +186,6 @@ $socialIconFontStack: 'icons';
   #{$property}: #{$value};
 }
 
-@mixin transition($transition: 0.1s all) {
-  @include prefix('transition', #{$transition});
-}
-
 @mixin transform($transform: 0.1s all) {
   @include prefix('transform', #{$transform});
 }
@@ -1934,13 +1930,13 @@ label.error {
   max-height: 0;
   visibility: hidden;
   overflow: hidden;
+  transition: all 300ms cubic-bezier(0.57, 0.06, 0.05, 0.95);
   @include backface(hidden);
-  @include transition(all 300ms cubic-bezier(0.57, 0.06, 0.05, 0.95));
 
   .mobile-nav--expanded + & {
     visibility: visible;
     max-height: 700px;
-    @include transition(all 700ms cubic-bezier(0.57, 0.06, 0.05, 0.95));
+    transition: all 700ms cubic-bezier(0.57, 0.06, 0.05, 0.95);
   }
 
   .mobile-nav__item:after {
@@ -1974,7 +1970,7 @@ label.error {
   z-index: $zindexDrawer;
   color: $colorDrawerText;
   background-color: $colorDrawers;
-  @include transition($drawerTransition);
+  transition: $drawerTransition;
 
   a {
     color: $colorDrawerText;
@@ -2026,7 +2022,7 @@ label.error {
 }
 
 .is-moved-by-drawer {
-  @include transition($drawerTransition);
+  transition: $drawerTransition;
 
   .js-drawer-open-left & {
     @include transform(translateX($drawerNavWidth));
@@ -2315,8 +2311,8 @@ label.error {
     max-height: 0;
     overflow: hidden;
     visibility: hidden;
+    transition: all 450ms cubic-bezier(0.57,.06,.05,.95);
     @include backface(hidden);
-    @include transition(all 450ms cubic-bezier(0.57,.06,.05,.95));
   }
 }
 
@@ -2401,7 +2397,7 @@ label.error {
 
   .is-loading & {
     opacity: 0.5;
-    @include transition(none);
+    transition: none;
   }
 }
 


### PR DESCRIPTION
* Removes unnecessary prefixing for `transition`, `linear-gradient`, `transform`, and `box-sizing`
* Replaces `prefix` mixin with `prefixer` inspired by [Bourbon's prefixer](https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/addons/_prefixer.scss).  Encourages only using necessary prefixes.
* Docs will have to be updated.

Test store: http://timber-dev.myshopify.com/