### PR TITLE
Fix JS error when ajax cart disabled

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -184,7 +184,7 @@ timber.accessibleNav = function () {
 timber.drawersInit = function () {
   timber.LeftDrawer = new timber.Drawers('NavDrawer', 'left');
   timber.RightDrawer = new timber.Drawers('CartDrawer', 'right', {
-    'onDrawerOpen': ajaxCart.load
+    {% if settings.ajax_cart_enable %}'onDrawerOpen': ajaxCart.load{% endif %}
   });
 };
 


### PR DESCRIPTION
Fixes #421 

Use liquid conditional to set `ajaxCart.load` function after drawer opens

@stevebosworth 