### PR TITLE
Product a11y fix

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -92,8 +92,6 @@
 
           {% if product.compare_at_price_max > product.price %}
             <span class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
-          {% else %}
-            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
           {% endif %}
           <span id="ProductPrice" class="h2" itemprop="price">
             {{ current_variant.price | money }}

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -90,13 +90,17 @@
             {% endfor %}
           </select>
 
-          <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
+          {% if product.compare_at_price_max > product.price %}
+            <span class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
+          {% else %}
+            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
+          {% endif %}
           <span id="ProductPrice" class="h2" itemprop="price">
             {{ current_variant.price | money }}
           </span>
 
           {% if product.compare_at_price_max > product.price %}
-            <span class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
+            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
             <p id="ComparePrice">
               {{ 'products.product.compare_at' | t }} {{ current_variant.compare_at_price | money }}
             </p>


### PR DESCRIPTION
@cshold @suture @cam 

Fixes for the issue with the a11y sales tag being incorrectly applied.  Fixes  #180. 

Looking at this again, I think it's somewhat overkill to have the `{{ products.general.regular_price | t }}` before `#ComparePrice` since we are using the `{{ products.product.compare_at }}` translation in that tag.  However, it's pretty common for that to get replaced by a strikeou, so I think it's still a good pattern to suggest in default timber templates.  Open to suggestions though.
