### PR TITLE
Prevent cart form submission while ajax running

### DIFF
--- a/assets/ajax-cart.js.liquid
+++ b/assets/ajax-cart.js.liquid
@@ -142,7 +142,7 @@ var ajaxCart = (function(module, $) {
   var init, loadCart;
 
   // Private general variables
-  var settings, $body;
+  var settings, isUpdating, $body;
 
   // Private plugin variables
   var $formContainer, $addToCart, $cartCountSelector, $cartCostSelector, $cartContainer, $drawerContainer;
@@ -179,6 +179,9 @@ var ajaxCart = (function(module, $) {
 
     // General Selectors
     $body = $('body');
+
+    // Track cart activity status
+    isUpdating = false;
 
     // Setup ajax quantity selectors on the any template if enableQtySelectors is true
     if (settings.enableQtySelectors) {
@@ -362,6 +365,13 @@ var ajaxCart = (function(module, $) {
       }
     });
 
+    // Prevent cart from being submitted while quantities are changing
+    $body.on('submit', 'form.ajaxcart', function(evt) {
+      if (isUpdating) {
+        evt.preventDefault();
+      }
+    });
+
     // Highlight the text when focused
     $body.on('focus', '.ajaxcart__qty-adjust', function() {
       var $el = $(this);
@@ -371,6 +381,8 @@ var ajaxCart = (function(module, $) {
     });
 
     function updateQuantity(line, qty) {
+      isUpdating = true;
+
       // Add activity classes when changing cart quantities
       var $row = $('.ajaxcart__row[data-line="' + line + '"]').addClass('is-loading');
 
@@ -394,6 +406,8 @@ var ajaxCart = (function(module, $) {
   };
 
   adjustCartCallback = function (cart) {
+    isUpdating = false;
+
     // Update quantity and price
     updateCountPrice(cart);
 

--- a/snippets/ajax-cart-template.liquid
+++ b/snippets/ajax-cart-template.liquid
@@ -8,7 +8,7 @@
 {% endcomment %}
   <script id="CartTemplate" type="text/template">
   {% raw %}
-    <form action="/cart" method="post" novalidate class="cart">
+    <form action="/cart" method="post" novalidate class="cart ajaxcart">
       <div class="ajaxcart__inner">
         {{#items}}
         <div class="ajaxcart__product">


### PR DESCRIPTION
**Issue:** With a single product in the cart, changing the quantity to 0 and then hitting enter tries to submit the form (not ajax), while the blur event on the quantity input removes the product from the cart. It's a race to see which happens first, but most of the time the form gives an ugly JS alert saying it can't submit an empty cart.

**Fix:** This PR stops the cart submission if the ajax quantity is currently running.

cc/ @stevebosworth (same update as Brooklyn)