### PR TITLE
Remove timber support email

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
 
         <div class="grid__item large--seven-twelfths push--large--one-sixth">
           <h4 class="footer-title">Feedback</h4>
-          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">Github</a>.<br> For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.</p>
+          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">Github</a>. For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.</p>
         </div>
       </div>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,8 +23,7 @@
 
         <div class="grid__item large--seven-twelfths push--large--one-sixth">
           <h4 class="footer-title">Feedback</h4>
-          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">Github</a> or send us feedback at <a href="mailto:timber@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">timber@shopify.com</a>.<br> For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.<br>
-          Follow the author <a href="https://twitter.com/cshold" title="Follow Us" class="footer-link">@cshold</a> on Twitter for updates.</p>
+          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">Github</a>.<br> For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Remove timber@ email to curb non-framework requests.

cc @mpiotrowicz @stevebosworth 