### PR TITLE
Change collection list paginate by count to match collection

### DIFF
--- a/templates/collection.list.liquid
+++ b/templates/collection.list.liquid
@@ -15,7 +15,7 @@
 
 {% endcomment %}
 
-{% paginate collection.products by 20 %}
+{% paginate collection.products by 12 %}
 
 {% include 'breadcrumb' %}
 


### PR DESCRIPTION
During a theme review with the Shopify team having different paginate by counts for the collection and collection list views came up as an issue.  Here are the steps to recreate the potential bug with mismatched pagination counts:

- Create a collection with 25 or more products
- The collection template will paginate over 3 pages
- Go to the last page
- Switch from collection to collection.list view
- Now you will see "Sorry, there are no products in this collection" since the page does not exist with the higher list pagination count.

It was incredibly helpful having Timber as a guideline to work from for our first theme.  Hopefully this small change will help someone else.