### PR TITLE
No need to call drawer prototype for focus trap

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -400,7 +400,7 @@ timber.Drawers = (function () {
     this.drawerIsOpen = true;
 
     // Set focus on drawer
-    Drawer.prototype.trapFocus(this.$drawer, 'drawer_focus');
+    this.trapFocus(this.$drawer, 'drawer_focus');
 
     // Run function when draw opens if set
     if (this.config.onDrawerOpen && typeof(this.config.onDrawerOpen) == 'function') {
@@ -441,7 +441,7 @@ timber.Drawers = (function () {
     this.drawerIsOpen = false;
 
     // Remove focus on drawer
-    Drawer.prototype.removeTrapFocus(this.$drawer, 'drawer_focus');
+    this.removeTrapFocus(this.$drawer, 'drawer_focus');
 
     this.$nodes.page.off('.drawer');
   };


### PR DESCRIPTION
Simplifying the call to `trapFocus` and `removeTrapFocus`