### PR TITLE
Better handling for onboarding in collections

### DIFF
--- a/templates/collection.liquid
+++ b/templates/collection.liquid
@@ -57,7 +57,7 @@
 
       {% else %}
 
-        {% if collection.handle == 'all' %}
+        {% if collection.handle == 'all' and current_tags == '' %}
 
           {% comment %}
             Add default products to help with onboarding for collections/all only


### PR DESCRIPTION
Currently Timber displays the onboarding message when `collection.handle == 'all'` returns no products.  There is one case where `/collection/all` does contain products, but if you use non-existent tags on `/collection/all` it shows onboarding rather than a "no products found" message.

I know it is a pretty rare edge case, but it came up during a Shopify theme review for submission.