### PR TITLE
Timber website nitpicks: capitalization, minor wording tweaks, etc

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,17 +13,17 @@
               <p><a href="https://ecommerce.shopify.com/c/ecommerce-design?utm_source=Timber&utm_medium=os" title="Meet the community" class="footer-link">Shopify Forums</a></p>
             </div>
             <div class="grid__item one-half">
-              <p><a href="http://www.shopify.ca/partners?utm_source=Timber&utm_medium=os" title="Earn money from referrals" class="footer-link">Partner Program</a></p>
+              <p><a href="https://www.shopify.com/partners?utm_source=Timber&utm_medium=os" title="Earn money from referrals" class="footer-link">Partner Program</a></p>
             </div>
             <div class="grid__item one-half">
-              <p><a href="http://docs.shopify.com/themes/liquid-basics?utm_source=Timber&utm_medium=os" title="Learn the basics of Liquid templating" class="footer-link">Liquid Basics</a></p>
+              <p><a href="https://docs.shopify.com/themes/liquid-basics?utm_source=Timber&utm_medium=os" title="Learn the basics of Liquid templating" class="footer-link">Liquid Basics</a></p>
             </div>
           </div>
         </div>
 
         <div class="grid__item large--seven-twelfths push--large--one-sixth">
           <h4 class="footer-title">Feedback</h4>
-          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">Github</a>. For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.</p>
+          <p>Submit issues on <a href="https://github.com/Shopify/Timber/issues" class="footer-link">GitHub</a>. For general Shopify theme support, reach out to <a href="mailto:themesupport@shopify.com?subject=Timber&nbsp;Feedback" class="footer-link">themesupport@shopify.com</a>.</p>
         </div>
       </div>
     </div>
@@ -36,7 +36,7 @@
           Timber {{ page.version }} © by Shopify Inc. Built and maintained by the <a href="mailto:timber@shopify.com" title="Corgis rule" class="footer-link">Themes Team</a>.
         </div>
         <div class="grid__item large--three-twelfths">
-          <a href="http://www.shopify.com?utm_source=Timber&utm_medium=os" title="Shopify Home" class="shopify-logo large--right">Shopify</a>
+          <a href="https://www.shopify.com?utm_source=Timber&utm_medium=os" title="Shopify Home" class="shopify-logo large--right">Shopify</a>
         </div>
       </div>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
 {% endif %}
 
 {% if page.canonical %}
-  <link rel="canonical" href="http://www.shopify.com{{ page.canonical }}">
+  <link rel="canonical" href="https://www.shopify.com{{ page.canonical }}">
 {% endif %}
 
 {% if page.hide_from_search %}

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ version: v2.1.2
     <a href="https://github.com/Shopify/Timber/archive/{{ page.version }}.zip" title="Download the .zip" class="btn-timber" data-track="Download" data-version="{{ page.version }}">Download Timber Theme</a>
     <p class="docs-text">
       Latest build: <span class="build-date">{{ page.version }}</span> •
-      <a href="https://github.com/Shopify/Timber" title="Get the source" class="text-link-on-orange">View Source on Github</a> •
+      <a href="https://github.com/Shopify/Timber" title="Get the source" class="text-link-on-orange">View Source on GitHub</a> •
       <a href="https://timber-demo.myshopify.com/" title="See Timber in action" class="text-link-on-orange" data-track="Demo" title="View Demo Store">View Demo Store</a>
     </p>
   </header>
@@ -57,9 +57,9 @@ version: v2.1.2
       <div class="grid__item large--three-quarters docs-body">
 
         <!-- =====================================
-          WHO IS THIS FOR
+          WHO THIS IS FOR
         ===================================== -->
-        <h2 class="doc-title gettingstarted-title" id="who-for"><strong>1.1 </strong>Who Is This For</h2>
+        <h2 class="doc-title gettingstarted-title" id="who-for"><strong>1.1 </strong>Who This Is For</h2>
         <p class="docs-text">Timber is a front-end framework which makes building Shopify themes quick and easy. It can be used by theme creators of any skill level for themes of any scope. Seasoned pros and newbies alike can benefit from the starter templates, liquid markup, modules, and CSS frameworks provided in Timber.</p>
 
         <hr class="hr--docshr">
@@ -87,7 +87,7 @@ version: v2.1.2
           </div>
           <div class="grid__item one-third small--one-whole">
             <h4 class="docs-h4">Other Ecommerce Features</h4>
-            <p class="docs-text"><a href="http://docs.shopify.com/manual/configuration/store-customization/advanced-navigation/add-a-reorder-drop-down-menu-to-a-collection-page" class="docs-link">Collection sorting</a>, <a href="https://dev.twitter.com/docs/cards/types/product-card" class="docs-link">Twitter Cards</a>, <a href="http://www.shopify.com/blog/14862781-pinterest-rich-pins-now-automatically-enabled-for-shopify-merchants" class="docs-link">Pinterest Rich Pins</a>, and <a href="https://schema.org/Product" class="docs-link">SEO-friendly Schema.org tags</a>.</p>
+            <p class="docs-text"><a href="https://docs.shopify.com/manual/configuration/store-customization/advanced-navigation/add-a-reorder-drop-down-menu-to-a-collection-page" class="docs-link">Collection sorting</a>, <a href="https://dev.twitter.com/docs/cards/types/product-card" class="docs-link">Twitter Cards</a>, <a href="https://www.shopify.com/blog/14862781-pinterest-rich-pins-now-automatically-enabled-for-shopify-merchants" class="docs-link">Pinterest Rich Pins</a>, and <a href="https://schema.org/Product" class="docs-link">SEO-friendly Schema.org tags</a>.</p>
           </div>
         </div>
 
@@ -105,7 +105,7 @@ git clone https://github.com/Shopify/Timber.git
         <div class="grid">
           <div class="grid__item one-half small--one-whole">
             <h4 class="docs-h4">Dev Notes</h4>
-            <p class="docs-text">Shopify Timber tested and working in IE 8+, Safari, Chrome, Firefox, Opera, Safari IOS, Browser and Chrome Android.</p>
+            <p class="docs-text">Shopify Timber has been tested to work in IE 8+, Safari, Chrome, Firefox, Opera, Safari for iOS, Chrome for Android, and the stock Android browser.</p>
           </div>
           <div class="grid__item one-half small--one-whole">
             <h4 class="docs-h4">Demo Store</h4>
@@ -123,7 +123,7 @@ git clone https://github.com/Shopify/Timber.git
         <div class="grid">
           <div class="grid__item one-half small--one-whole">
             <h4 class="docs-h4">Theme Gem</h4>
-            <p class="docs-text">If you're comfortable with the command line, use the <a href="https://github.com/Shopify/shopify_theme" class="docs-link">Shopify Theme Gem</a> on OSX or Windows to upload changes to your theme with ease.</p>
+            <p class="docs-text">If you're comfortable with the command line, use the <a href="https://github.com/Shopify/shopify_theme" class="docs-link">Shopify Theme Gem</a> on OS X or Windows to upload changes to your theme with ease.</p>
           </div>
           <div class="grid__item one-half small--one-whole">
             <h4 class="docs-h4">Desktop Theme Editor</h4>
@@ -137,7 +137,7 @@ git clone https://github.com/Shopify/Timber.git
           SELL YOUR THEME
         ===================================== -->
         <h2 class="doc-title gettingstarted-title" id="demos"><strong>1.5 </strong>Sell Your Theme</h2>
-        <p class="docs-text">You can sell your theme in <a href="https://themes.shopify.com?utm_source=Timber&utm_medium=os" class="docs-link">Shopify's Theme Store</a> by following our <a href="https://themes.shopify.com/services/themes/guidelines?utm_source=Timber&utm_medium=os" class="docs-link">Guideline Checklist</a>. You can also earn 20% of each customer’s bill that you refer to Shopify by enrolling in the <a href="http://www.shopify.com/partners?utm_source=Timber&utm_medium=os" class="docs-link">Shopify Partner Program</a>.</p>
+        <p class="docs-text">You can sell your theme on the <a href="https://themes.shopify.com?utm_source=Timber&utm_medium=os" class="docs-link">Shopify Theme Store</a> by following our <a href="https://themes.shopify.com/services/themes/guidelines?utm_source=Timber&utm_medium=os" class="docs-link">Guideline Checklist</a>. You can also earn 20% of each customer’s bill that you refer to Shopify by enrolling in the <a href="https://www.shopify.com/partners?utm_source=Timber&utm_medium=os" class="docs-link">Shopify Partner Program</a>.</p>
 
         <hr class="hr--docshr">
 
@@ -1418,7 +1418,7 @@ jQuery('body').on('ajaxCart.afterCartLoad', function(evt, cart) {
               </div>
             </div>
             <div class="grid__item large--one-half">
-              <h4 class="docs-example">Example 2 - Mailchimp Integration</h4>
+              <h4 class="docs-example">Example 2 - MailChimp Integration</h4>
               <form class="input-group">
                 <input type="email" value="" placeholder="Email address" class="input-group-field">
                 <span class="input-group-btn">
@@ -1585,7 +1585,7 @@ jQuery('body').on('ajaxCart.afterCartLoad', function(evt, cart) {
             <li>
               <div class="icon-fallback-text">
                 <span class="icon icon-master"></span>
-                <span class="fallback-text">Master Card</span>
+                <span class="fallback-text">MasterCard</span>
               </div>
             </li>
             <li>
@@ -1792,7 +1792,7 @@ jQuery('body').on('ajaxCart.afterCartLoad', function(evt, cart) {
   &lt;li&gt;
     &lt;div class="icon-fallback-text"&gt;
       &lt;span class="icon icon-master"&gt;&lt;/span&gt;
-      &lt;span class="fallback-text"&gt;Master Card&lt;/span&gt;
+      &lt;span class="fallback-text"&gt;MasterCard&lt;/span&gt;
     &lt;/div&gt;
   &lt;/li&gt;
   &lt;li&gt;


### PR DESCRIPTION
@cshold I was taking a look at Timber today and noticed a few little nitpicky things on the website.

* Changed one link from shopify.ca to shopify.com.
* Changed a bunch of Brochure/docs links to HTTPS because why not (users get redirected to HTTPS anyway).
* Fixed capitalization/spacing: Github => GitHub, Master Card => MasterCard, Mailchimp => MailChimp.
* `Who Is This For` heading changed to `Who This Is For`
* Changed wording for browser support - it sounded a bit awkward given that the stock Android browser is named Browser.