### PR TITLE
Add data-sku to option on product page

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -80,7 +80,7 @@
                 {% comment %}
                   Note: if you use option_selection.js, your <select> tag will be overwritten, meaning what you have inside <option> will not reflect what you coded below.
                 {% endcomment %}
-                <option {% if variant == product.selected_or_first_available_variant %} selected="selected" {% endif %} value="{{ variant.id }}">{{ variant.title }} - {{ variant.price | money_with_currency }}</option>
+                <option {% if variant == product.selected_or_first_available_variant %} selected="selected" {% endif %} data-sku="{{ variant.sku }}" value="{{ variant.id }}">{{ variant.title }} - {{ variant.price | money_with_currency }}</option>
 
               {% else %}
                 <option disabled="disabled">


### PR DESCRIPTION
Lets Google Analytics use a product's sku rather than variant ID.

@fredryk 