### PR TITLE
[Timber] fix responsive video bug

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -280,8 +280,21 @@ timber.switchImage = function (src, imgObject, el) {
 };
 
 timber.responsiveVideos = function () {
-  $('iframe[src*="youtube.com/embed"]').wrap('<div class="video-wrapper"></div>');
-  $('iframe[src*="player.vimeo"]').wrap('<div class="video-wrapper"></div>');
+  var $iframeVideo = $('iframe[src*="youtube.com/embed"], iframe[src*="player.vimeo"]');
+  var $iframeReset = $iframeVideo.add('iframe#admin_bar_iframe');
+
+  $iframeVideo.each(function () {
+    // Add wrapper to make video responsive
+    $(this).wrap('<div class="video-wrapper"></div>');
+  });
+
+  $iframeReset.each(function () {
+    // Re-set the src attribute on each iframe after page load
+    // for Chrome's "incorrect iFrame content on 'back'" bug.
+    // https://code.google.com/p/chromium/issues/detail?id=395791
+    // Need to specifically target video and admin bar
+    this.src = this.src;
+  });
 };
 
 timber.collectionViews = function () {


### PR DESCRIPTION
This is a fix to address a small bug in our last fix for the chrome iframe bug. Shopify Themes issue originally logged and updated here https://github.com/Shopify/shopify-themes/issues/1326#issuecomment-138707078 (private repo)

To summarize, when multiple videos are displayed on a page, things work fine initially. When moving to another page and then using the browsers back button, the previous videos will all be the same source. 
Chromium issue logged here https://code.google.com/p/chromium/issues/detail?id=395791

@cshold this should be good to go as its the same code we have already merges on all our internal timber themes. Just wanna double check before merging 
