### PR TITLE
Update article comment form ids

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -198,11 +198,6 @@ timber.getHash = function () {
   return window.location.hash;
 };
 
-timber.updateHash = function (hash) {
-  window.location.hash = '#' + hash;
-  $('#' + hash).attr('tabindex', -1).focus();
-};
-
 timber.productPage = function (options) {
   var moneyFormat = options.money_format,
       variant = options.variant,

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -382,11 +382,6 @@
     Template-specific js
   {% endcomment %}
   <script>
-    {% if newHash %}
-      $(function() {
-        timber.updateHash('{{ newHash }}');
-      });
-    {% endif %}
     {% if resetPassword %}
       $(function() {
         timber.resetPasswordSuccess();

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -77,9 +77,9 @@
       {% endcomment %}
       {% paginate article.comments by 5 %}
         {% comment %}
-          #Comments is required, it is used as an anchor link by Shopify.
+          #comments is required, it is used as an anchor link by Shopify.
         {% endcomment %}
-        <div id="Comments">
+        <div id="comments">
 
           {% if comment and comment.created_at %}
             <p class="note form-success">
@@ -128,15 +128,12 @@
           {% endif %}
 
           {% comment %}
-            Comment submission form
+            #comment-form is required, it is used as an anchor link by Shopify
+            when an error occurs during submission.
           {% endcomment %}
-          <div class="form-vertical">
+          <div id="comment-form" class="form-vertical">
             {% form 'new_comment', article %}
-
-              {% comment %}
-                #AddCommentTitle is used simply as an anchor link
-              {% endcomment %}
-              <h3 id="AddCommentTitle">{{ 'blogs.comments.title' | t }}</h3>
+              <h3>{{ 'blogs.comments.title' | t }}</h3>
 
               {{ form.errors | default_errors }}
 
@@ -162,18 +159,6 @@
               {% endif %}
 
               <input type="submit" class="btn" value="{{ 'blogs.comments.post' | t }}">
-
-              {% comment %}
-                Assign variable to be used after timber.init() is run in theme.liquid
-              {% endcomment %}
-              {% if form.errors %}
-                {% assign newHash = 'AddCommentTitle' %}
-              {% endif %}
-
-              {% if form.posted_successfully? %}
-                {% assign newHash = 'Comments' %}
-              {% endif %}
-
             {% endform %}
           </div>
 

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -127,11 +127,7 @@
 
           {% endif %}
 
-          {% comment %}
-            #comment-form is required, it is used as an anchor link by Shopify
-            when an error occurs during submission.
-          {% endcomment %}
-          <div id="comment-form" class="form-vertical">
+          <div class="form-vertical">
             {% form 'new_comment', article %}
               <h3>{{ 'blogs.comments.title' | t }}</h3>
 


### PR DESCRIPTION
A pending PR in Shopify (https://github.com/Shopify/shopify/pull/57450) will reload the page after a comment form submission with either `#comments` or `#comment-form` as a hash in the URL.

- `#comments` already works as expected on a successful post
- `#comment-form` will be added when the form has errors, jumping the page down to the anchor on the form so the user can fix the mistakes

This PR removes the hacky JS that got around having accurate URL hashes and updates the IDs.

cc @Shopify/themes-team @mac-adam-chaieb 

FYI @Shopify/theme-support, this can be a reference for updating other themes. Ping me with any questions.