### PR TITLE
Content style update

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -184,7 +184,7 @@ timber.accessibleNav = function () {
 timber.drawersInit = function () {
   timber.LeftDrawer = new timber.Drawers('NavDrawer', 'left');
   timber.RightDrawer = new timber.Drawers('CartDrawer', 'right', {
-    {% if settings.ajax_cart_enable %}'onDrawerOpen': ajaxCart.load{% endif %}
+    {% if settings.ajax_cart_method == "drawer" %}'onDrawerOpen': ajaxCart.load{% endif %}
   });
 };
 

--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -2405,7 +2405,7 @@ label.error {
 /*============================================================================
   #Ajax Cart Styles (conditionally loaded)
 ==============================================================================*/
-{% if settings.ajax_cart_enable %}
+{% if settings.ajax_cart_method == "drawer" %}
 
 .ajaxcart__inner {
   margin-bottom: $gutter;
@@ -2539,4 +2539,4 @@ label.error {
   border-color: $colorDrawerBorder;
 }
 
-{% endif %} // settings.ajax_cart_enable
+{% endif %} // settings.ajax_cart_method

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -2,7 +2,7 @@
   "current": "Default",
   "presets": {
     "Default": {
-      "ajax_cart_enable": true,
+      "ajax_cart_method": "drawer",
       "cart_notes_enable": true,
       "color_body_bg": "#fff",
       "color_body_text": "#333333",
@@ -16,8 +16,8 @@
       "footer_newsletter_enable": true,
       "footer_social_enable": true,
       "logo_use_image": false,
-      "social_facebook_link": "https://www.facebook.com/shopify",
-      "social_twitter_link": "https://twitter.com/shopify"
+      "social_facebook_link": "",
+      "social_twitter_link": ""
     }
   }
 }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -30,42 +30,42 @@
       },
       {
         "type": "header",
-        "content": "General Colors"
+        "content": "General colors"
       },
       {
         "type": "color",
         "id": "color_primary",
-        "label": "Primary Color",
+        "label": "Primary",
         "default": "#204a80",
         "info": "Used for text links, and primary buttons"
       },
       {
         "type": "color",
         "id": "color_secondary",
-        "label": "Secondary Color",
+        "label": "Secondary",
         "default": "#dcdcdc",
         "info": "Used for secondary buttons"
       },
       {
         "type": "color",
         "id": "color_body_bg",
-        "label": "Body Background",
+        "label": "Body background",
         "default": "#ffffff"
       },
       {
         "type": "color",
         "id": "color_borders",
-        "label": "Border Colors",
+        "label": "Borders",
         "default": "#e5e5e5"
       },
       {
         "type": "header",
-        "content": "Body Text"
+        "content": "Body text"
       },
       {
         "type": "color",
         "id": "color_body_text",
-        "label": "Body Text",
+        "label": "Body text",
         "default": "#333333"
       },
       {
@@ -75,19 +75,19 @@
       {
         "type": "color",
         "id": "color_footer_bg",
-        "label": "Footer Background",
+        "label": "Footer background",
         "default": "#f2f2f2"
       },
       {
         "type": "color",
         "id": "color_footer_text",
-        "label": "Footer Text",
+        "label": "Footer text",
         "default": "#636363"
       },
       {
         "type": "color",
         "id": "color_footer_social_link",
-        "label": "Social Icons",
+        "label": "Social icons",
         "default": "#bbbbbb"
       }
     ]
@@ -102,12 +102,12 @@
       {
         "type": "checkbox",
         "id": "logo_use_image",
-        "label": "Use Custom Logo"
+        "label": "Use custom logo"
       },
       {
         "type": "image",
         "id": "logo.png",
-        "label": "Custom Logo",
+        "label": "Custom logo",
         "max-width": 450,
         "max-height": 200,
         "info": "Maximum logo dimensions are 450px wide by 200px high. The uploaded file will be resized to fit within those constraints."
@@ -115,7 +115,7 @@
       {
         "type": "text",
         "id": "logo_max_width",
-        "label": "Max Logo Width",
+        "label": "Max logo width",
         "default": "450",
         "info": "Defined in pixels. Do not add the 'px' unit."
       },
@@ -126,12 +126,12 @@
       {
         "type": "checkbox",
         "id": "favicon_enable",
-        "label": "Use custom icon?"
+        "label": "Use custom icon"
       },
       {
         "type": "image",
         "id": "favicon.png",
-        "label": "16px x 16px png",
+        "label": "16 x 16px png",
         "max-width": 16,
         "max-height": 16
       }
@@ -143,38 +143,40 @@
       {
         "type": "checkbox",
         "id": "footer_social_enable",
-        "label": "Show social media links"
+        "label": "Show social media icons"
       },
       {
         "type": "text",
         "id": "social_twitter_link",
-        "label": "Twitter link"
+        "label": "Twitter URL",
+        "info": "https://twitter.com/shopify"
       },
       {
         "type": "text",
         "id": "social_facebook_link",
-        "label": "Facebook link"
+        "label": "Facebook URL",
+        "info": "https://www.facebook.com/shopify"
       },
       {
         "type": "checkbox",
         "id": "footer_newsletter_enable",
-        "label": "Show Newsletter Field"
+        "label": "Show newsletter field"
       },
       {
         "type": "text",
         "id": "newsletter_form_action",
-        "label": "MailChimp Form Action URL",
+        "label": "MailChimp form action URL",
         "info": "[Where do I find my MailChimp form action URL?](http:\/\/docs.shopify.com\/support\/configuration\/store-customization\/where-do-i-get-my-mailchimp-form-action)"
       }
     ]
   },
   {
-    "name": "Cart Page",
+    "name": "Cart page",
     "settings": [
       {
         "type": "checkbox",
         "id": "cart_notes_enable",
-        "label": "Allow notes with orders"
+        "label": "Enable cart notes"
       },
       {
         "type": "checkbox",
@@ -184,19 +186,19 @@
       {
         "type": "checkbox",
         "id": "ajax_cart_enable",
-        "label": "Enable Ajax Cart Drawer",
+        "label": "Enable Ajax cart drawer",
         "info": "[View Documentation](http:\/\/shopify.com\/timber#ajax-cart)"
       }
     ]
   },
   {
-    "name": "Social Sharing",
+    "name": "Social media",
     "settings": [
       {
         "type": "text",
         "id": "twittercard_handle",
-        "label": "Twitter Handle",
-        "default": "@"
+        "label": "Twitter handle",
+        "info": "@shopify"
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -48,24 +48,24 @@
       },
       {
         "type": "color",
-        "id": "color_body_bg",
-        "label": "Body background",
-        "default": "#ffffff"
-      },
-      {
-        "type": "color",
         "id": "color_borders",
         "label": "Borders",
         "default": "#e5e5e5"
       },
       {
         "type": "header",
-        "content": "Body text"
+        "content": "Body"
+      },
+      {
+        "type": "color",
+        "id": "color_body_bg",
+        "label": "Background",
+        "default": "#ffffff"
       },
       {
         "type": "color",
         "id": "color_body_text",
-        "label": "Body text",
+        "label": "Text",
         "default": "#333333"
       },
       {
@@ -75,19 +75,19 @@
       {
         "type": "color",
         "id": "color_footer_bg",
-        "label": "Footer background",
+        "label": "Background",
         "default": "#f2f2f2"
       },
       {
         "type": "color",
         "id": "color_footer_text",
-        "label": "Footer text",
+        "label": "Text",
         "default": "#636363"
       },
       {
         "type": "color",
         "id": "color_footer_social_link",
-        "label": "Social icons",
+        "label": "Social media icons",
         "default": "#bbbbbb"
       }
     ]
@@ -149,13 +149,13 @@
         "type": "text",
         "id": "social_twitter_link",
         "label": "Twitter URL",
-        "info": "https://twitter.com/shopify"
+        "info": "Example: https://twitter.com/shopify"
       },
       {
         "type": "text",
         "id": "social_facebook_link",
         "label": "Facebook URL",
-        "info": "https://www.facebook.com/shopify"
+        "info": "Example: https://www.facebook.com/shopify"
       },
       {
         "type": "checkbox",
@@ -184,10 +184,19 @@
         "label": "Show product vendor"
       },
       {
-        "type": "checkbox",
-        "id": "ajax_cart_enable",
-        "label": "Enable Ajax cart drawer",
-        "info": "[View Documentation](http:\/\/shopify.com\/timber#ajax-cart)"
+        "type": "select",
+        "id": "ajax_cart_method",
+        "label": "Cart type",
+        "options": [
+          {
+            "value": "drawer",
+            "label": "Drawer"
+          },
+          {
+            "value": "page",
+            "label": "Page"
+          }
+        ]
       }
     ]
   },
@@ -198,7 +207,7 @@
         "type": "text",
         "id": "twittercard_handle",
         "label": "Twitter handle",
-        "info": "@shopify"
+        "info": "Example: @shopify"
       }
     ]
   }

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -394,7 +394,7 @@
     Documentation:
       - http://shopify.com/timber#ajax-cart
   {% endcomment %}
-  {% if settings.ajax_cart_enable %}
+  {% if settings.ajax_cart_method == "drawer" %}
     {{ 'handlebars.min.js' | asset_url | script_tag }}
     {% include 'ajax-cart-template' %}
     {{ 'ajax-cart.js' | asset_url | script_tag }}


### PR DESCRIPTION
Updates for https://github.com/Shopify/Timber/issues/486

We In addition to going through content checklist here https://docs.shopify.com/themes/theme-development/theme-store-requirements/content-style-guide

The Shopify themes team also decided to try and steer away from using the word Ajax in the theme settings as it's not meaningful to most merchants. The new option is a dropdown for cart type 

[![alt](https://screenshot.click/19-40-gqlvn-4mf8f.jpg)](https://screenshot.click/19-40-gqlvn-4mf8f.jpg)

Drawer will trigger the ajax drawer, Page will disable ajax and redirect to /cart on form submission. Additionally, developers and designers are also encouraged to use Modal, Flipdown, or other design types in the dropdown as wish. 

@virginiastart @cshold I don't think I missed anything, but a double check is always good. 