### PR TITLE
Add Shopify newsletter fallback

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -331,21 +331,37 @@
                 Use the link below to find your MailChimp form action
                 and insert it in your site settings.
 
+                If the form action URL is not set in the theme settings, 
+                it will fallback to a customer form so you can still capture the email.
+                
                 MailChimp newsletter integration and requirement:
                  - http://docs.shopify.com/support/configuration/store-customization/where-do-i-get-my-mailchimp-form-action
               {% endcomment %}
               <h3>{{ 'layout.footer.newsletter_title' | t }}</h3>
               {% if settings.newsletter_form_action != blank %}
-                {% assign form_action = settings.newsletter_form_action %}
+                <form action="{{ settings.newsletter_form_action }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" class="input-group">
+                  <input type="email" value="{% if customer %}{{ customer.email }}{% endif %}" placeholder="{{ 'general.newsletter_form.newsletter_email' | t }}" name="EMAIL" id="mail" class="input-group-field" aria-label="{{ 'general.newsletter_form.newsletter_email' | t }}" autocorrect="off" autocapitalize="off">
+                  <span class="input-group-btn">
+                    <input type="submit" class="btn" name="subscribe" id="subscribe" value="{{ 'general.newsletter_form.submit' | t }}">
+                  </span>
+                </form>
               {% else %}
-                {% assign form_action = '#' %}
+                {% form 'customer' %}
+                  {{ form.errors | default_errors }}
+                  {% if form.posted_successfully? %}
+                    <p class="note form-success">{{ 'general.newsletter_form.confirmation' | t }}</p>
+                  {% else %}
+                    <div class="input-group">
+                      <input type="email" value="{% if customer %}{{ customer.email }}{% endif %}" placeholder="{{ 'general.newsletter_form.newsletter_email' | t }}" name="contact[email]" id="Email" class="input-group-field" aria-label="{{ 'general.newsletter_form.newsletter_email' | t }}" autocorrect="off" autocapitalize="off">
+                      <input type="hidden" name="contact[tags]" value="newsletter">
+                      <span class="input-group-btn">
+                        <input type="submit" class="btn" name="subscribe" id="subscribe" value="{{ 'general.newsletter_form.submit' | t }}">
+                      </span>
+                    </div>
+                  {% endif %}
+                {% endform %}
               {% endif %}
-              <form action="{{ form_action }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" class="input-group">
-                <input type="email" value="{% if customer %}{{ customer.email }}{% endif %}" placeholder="{{ 'general.newsletter_form.newsletter_email' | t }}" name="EMAIL" id="mail" class="input-group-field" aria-label="{{ 'general.newsletter_form.newsletter_email' | t }}" autocorrect="off" autocapitalize="off">
-                <span class="input-group-btn">
-                  <input type="submit" class="btn" name="subscribe" id="subscribe" value="{{ 'general.newsletter_form.submit' | t }}">
-                </span>
-              </form>
+              
             </div>
           {% endif %}
           <div class="grid__item text-center">

--- a/locales/de.json
+++ b/locales/de.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "email@beispiel.com",
-      "submit": "Abonnieren"
+      "submit": "Abonnieren",
+      "confirmation": "Danke fürs Anmelden"
     },
     "search": {
       "no_results_html": "Ihre Suche nach \"{{ terms }}\" hat keine Ergebnisse hervorgebracht.",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "email@example.com",
-      "submit": "Subscribe"
+      "submit": "Subscribe",
+      "confirmation": "Thanks for subscribing"
     },
     "search": {
       "no_results_html": "Your search for \"{{ terms }}\" did not yield any results.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "email@ejemplo.com",
-      "submit": "Suscribir"
+      "submit": "Suscribir",
+      "confirmation": "Gracias por suscribirse"
     },
     "search": {
       "no_results_html": "Su búsqueda de \"{{ terms }}\" no tuvo resultados.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "courriel@exemple.com",
-      "submit": "S'inscrire"
+      "submit": "S'inscrire",
+      "confirmation": "Merci de vous être inscrit"
     },
     "search": {
       "no_results_html": "Votre recherche pour \"{{ terms }}\" n'a pas généré de résultats.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "e-mail@exemplo.com",
-      "submit": "Inscrever"
+      "submit": "Inscrever",
+      "confirmation": "Obrigado por assinar"
     },
     "search": {
       "no_results_html": "Sua busca por \"{{ terms }}\" não gerou resultados.",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -14,7 +14,8 @@
     },
     "newsletter_form": {
       "newsletter_email": "email@exemplo.com",
-      "submit": "Subscrever"
+      "submit": "Subscrever",
+      "confirmation": "Obrigado pela sua subscrição"
     },
     "search": {
       "no_results_html": "A sua pesquisa por \"{{ terms }}\" não produziu resultados.",


### PR DESCRIPTION
Adding Shopify newsletter form as default for the newsletter form. Once the merchant adds their MailChimp URL then we can switch the form over to use MailChimp. This way merchants will be collecting customers info in the early stages when they haven't set up their MailChimp account or even 5 years later when they finally discover MailChimp!

Review @karocena @cshold  :eyes: 