### PR TITLE
Update blog comments json

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -42,7 +42,7 @@
       "moderated": "Bitte beachten Sie, dass Kommentare vor der Veröffentlichung freigegeben werden müssen",
       "success_moderated": "Ihr Kommentar wurde erfolgreich gepostet. Da unser Blog moderiert wird, werden wir ihn erst kurze Zeit später veröffentlichen.",
       "success": "Ihr Kommentar wurde erfolgreich gepostet. Danke!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} Kommentar",
         "other": "{{ count }} Kommentare"
       }

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -42,7 +42,7 @@
       "moderated": "Please note, comments must be approved before they are published",
       "success_moderated": "Your comment was posted successfully. We will publish it in a little while, as our blog is moderated.",
       "success": "Your comment was posted successfully! Thank you!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} comment",
         "other": "{{ count }} comments"
       }

--- a/locales/es.json
+++ b/locales/es.json
@@ -42,7 +42,7 @@
       "moderated": "Por favor tenga en cuenta que los comentarios deben ser aprobados antes de ser publicados",
       "success_moderated": "Su comentario se ha compartido con éxito. Lo publicaremos en un momento, en tanto nuestro blog sea moderado.",
       "success": "¡Su comentario se ha compartido con éxito! ¡Gracias!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} comentario",
         "other": "{{ count }} comentarios"
       }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -42,7 +42,7 @@
       "moderated": "Veuillez noter que les commentaires doivent être approvés avant d'être affichés",
       "success_moderated": "Votre commentaire a été soumis avec succès. Nous le publierons sous peu, suite à notre processus de modération.",
       "success": "Votre commentaire a été publié avec succès!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} commentaire",
         "other": "{{ count }} commentaires"
       }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -42,7 +42,7 @@
       "moderated": "Observe que os comentários precisam ser aprovados antes de serem publicados",
       "success_moderated": "Seu comentário foi postado. Nós o publicaremos em alguns instantes, já que o nosso blog é moderado.",
       "success": "Seu comentário foi postado! Obrigado!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} comentário",
         "other": "{{ count }} comentários"
       }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -42,7 +42,7 @@
       "moderated": "Tenha em atenção que os comentários precisam de ser aprovados antes de serem exibidos",
       "success_moderated": "O seu comentário foi publicado com sucesso! Obrigado!",
       "success": "Seu comentário foi postado! Obrigado!",
-      "comments_with_count": {
+      "with_count": {
         "one": "{{ count }} comentário",
         "other": "{{ count }} comentários"
       }

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -68,7 +68,7 @@
     {% if blog.comments_enabled? %}
       <hr>
 
-      <h3>{{ 'blogs.comments.comments_with_count' | t: count: number_of_comments }}</h3>
+      <h3>{{ 'blogs.comments.with_count' | t: count: number_of_comments }}</h3>
 
       <hr>
 

--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -65,7 +65,7 @@
           {% if blog.comments_enabled? %}
           <li>
             <a href="{{ article.url }}#comments">
-              {{ 'blogs.comments.comments_with_count' | t: count: article.comments_count }}
+              {{ 'blogs.comments.with_count' | t: count: article.comments_count }}
             </a>
           </li>
           {% endif %}

--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -149,7 +149,7 @@
         <li>
           <a href="{{ article.url }}#comments">
             {{ article.comments_count }}
-            {{ 'blogs.comments.comments_with_count' | t: count: article.comments_count }}
+            {{ 'blogs.comments.with_count' | t: count: article.comments_count }}
           </a>
         </li>
         {% endif %}


### PR DESCRIPTION
Having `comments_with_count` causes the i18n page to display "Comments comments with count". This changes it to just "Comments with count".

![https://cloud.githubusercontent.com/assets/11576030/8382929/65821704-1c04-11e5-87d2-e8d62f98b5cd.png](https://cloud.githubusercontent.com/assets/11576030/8382929/65821704-1c04-11e5-87d2-e8d62f98b5cd.png)

review: @matcaissy 

cc @cshold 