### PR TITLE
Show account creation link when accounts are required

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -124,11 +124,9 @@
           <li class="mobile-nav__item">
             {{ 'layout.customer.log_in' | t | customer_login_link }}
           </li>
-          {% if shop.customer_accounts_optional %}
           <li class="mobile-nav__item">
             {{ 'layout.customer.create_account' | t | customer_register_link }}
           </li>
-          {% endif %}
         {% endif %}
       {% endif %}
     </ul>
@@ -208,9 +206,7 @@
                   | {{ 'layout.customer.log_out' | t | customer_logout_link }}
                 {% else %}
                   {{ 'layout.customer.log_in' | t | customer_login_link }}
-                  {% if shop.customer_accounts_optional %}
                   | {{ 'layout.customer.create_account' | t | customer_register_link }}
-                  {% endif %}
                 {% endif %}
               </div>
             {% endif %}

--- a/templates/customers/login.liquid
+++ b/templates/customers/login.liquid
@@ -31,7 +31,8 @@
         <p>
           <input type="submit" class="btn btn--full" value="{{ 'customer.login.sign_in' | t }}">
         </p>
-        <p><a href="{{ shop.url }}">{{ 'customer.login.cancel' | t }}</a></p>
+        <p><a href="/">{{ 'customer.login.cancel' | t }}</a></p>
+        <p>{{ 'layout.customer.create_account' | t | customer_register_link }}</p>
         {% if form.password_needed %}
           <p><a href="#recover" id="RecoverPassword">{{ 'customer.login.forgot_password' | t }}</a></p>
         {% endif %}


### PR DESCRIPTION
Since `/account/register` is available, and since one can create a account from any page using a `POST` request, let's show the account creation link when accounts are required — same as when accounts are optional.