### PR TITLE
Remove color setting help text

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -25,10 +25,6 @@
     "name": "Colors",
     "settings": [
       {
-        "type": "paragraph",
-        "content": "Use class=\"color\" on a an input tag to bring up the color picker. Only a few colors have been included here as an example."
-      },
-      {
         "type": "header",
         "content": "General colors"
       },


### PR DESCRIPTION
There are some leftover text in the theme settings from the days of `settings.html`. This only confuses people since theme settings are coded differently now. 

![https://screenshot.click/28-23-le6a5-nx0au.jpg](https://screenshot.click/28-23-le6a5-nx0au.jpg)

@cshold 