### PR TITLE
Disable cart drawer when setting is page

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -183,9 +183,11 @@ timber.accessibleNav = function () {
 
 timber.drawersInit = function () {
   timber.LeftDrawer = new timber.Drawers('NavDrawer', 'left');
-  timber.RightDrawer = new timber.Drawers('CartDrawer', 'right', {
-    {% if settings.ajax_cart_method == "drawer" %}'onDrawerOpen': ajaxCart.load{% endif %}
-  });
+  {% if settings.ajax_cart_method == "drawer" %}
+    timber.RightDrawer = new timber.Drawers('CartDrawer', 'right', {
+      'onDrawerOpen': ajaxCart.load
+    });
+  {% endif %}
 };
 
 timber.mobileNavToggle = function () {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -132,18 +132,20 @@
     </ul>
     <!-- //mobile-nav -->
   </div>
-  <div id="CartDrawer" class="drawer drawer--right">
-    <div class="drawer__header">
-      <div class="drawer__title h3">{{ 'cart.general.title' | t }}</div>
-      <div class="drawer__close js-drawer-close">
-        <button type="button" class="icon-fallback-text">
-          <span class="icon icon-x" aria-hidden="true"></span>
-          <span class="fallback-text">{{ 'cart.general.close_cart' | t | json }}</span>
-        </button>
+  {% if settings.ajax_cart_method == "drawer" %}
+    <div id="CartDrawer" class="drawer drawer--right">
+      <div class="drawer__header">
+        <div class="drawer__title h3">{{ 'cart.general.title' | t }}</div>
+        <div class="drawer__close js-drawer-close">
+          <button type="button" class="icon-fallback-text">
+            <span class="icon icon-x" aria-hidden="true"></span>
+            <span class="fallback-text">{{ 'cart.general.close_cart' | t | json }}</span>
+          </button>
+        </div>
       </div>
+      <div id="CartContainer"></div>
     </div>
-    <div id="CartContainer"></div>
-  </div>
+  {% endif %}
   <div id="PageContainer" class="is-moved-by-drawer">
     <header class="site-header" role="banner">
       <div class="wrapper">
@@ -327,9 +329,9 @@
                 Use the link below to find your MailChimp form action
                 and insert it in your site settings.
 
-                If the form action URL is not set in the theme settings, 
+                If the form action URL is not set in the theme settings,
                 it will fallback to a customer form so you can still capture the email.
-                
+
                 MailChimp newsletter integration and requirement:
                  - http://docs.shopify.com/support/configuration/store-customization/where-do-i-get-my-mailchimp-form-action
               {% endcomment %}
@@ -357,7 +359,7 @@
                   {% endif %}
                 {% endform %}
               {% endif %}
-              
+
             </div>
           {% endif %}
           <div class="grid__item text-center">


### PR DESCRIPTION
Fixes #516 and fixes #507

The original purpose of the cart/drawer setting was for what happens after you add a product to the cart. It's confusing the way it's worded in settings as you'd think the drawer would be completely disabled when selecting 'Page'.
![image](https://cloud.githubusercontent.com/assets/1730309/13437909/8c3bf65c-dfb4-11e5-9716-a3c268026f07.png)

This PR completely removes the cart drawer when 'Page' is selected.

@stevebosworth @carolineschnapp @t-kelly @m-ux 