### PR TITLE
Fix iOS Safari off canvas scaling issues

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -24,7 +24,7 @@
   <!-- Helpers ================================================== -->
   {% include 'social-meta-tags' %}
   <link rel="canonical" href="{{ canonical_url }}">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   <meta name="theme-color" content="{{ settings.color_primary }}">
 
   <!-- CSS ================================================== -->


### PR DESCRIPTION
This fixes the changes in the way Safari interprets zooming and overflow on objects. As Apple consider their changes to be the right way to do things, they probably aren’t going to be changing the behaviour any time soon.