### PR TITLE
[Timber] update a11y headings and remove stripe icon whitelist

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -368,7 +368,7 @@
               Loop through available payment methods and show their icons.
             {% endcomment %}
             {% unless shop.enabled_payment_types == empty %}
-              {% assign payment_icons_available = 'amazon_payments,american_express,bitcoin,cirrus,dankort,diners_club,discover,dogecoin,dwolla,forbrugsforeningen,interac,jcb,litecoin,maestro,master,paypal,stripe,visa' | split: ',' %}
+              {% assign payment_icons_available = 'amazon_payments,american_express,bitcoin,cirrus,dankort,diners_club,discover,dogecoin,dwolla,forbrugsforeningen,interac,jcb,litecoin,maestro,master,paypal,visa' | split: ',' %}
               <h4 class="text-center">{{ 'layout.footer.accepted_payments' | t }}</h4>
               <ul class="inline-list payment-icons">
                 {% for type in shop.enabled_payment_types %}

--- a/snippets/blog-sidebar.liquid
+++ b/snippets/blog-sidebar.liquid
@@ -2,7 +2,7 @@
 {% comment %}
   Recent blog posts
 {% endcomment %}
-<h2 class="h4">{{ 'blogs.sidebar.recent_articles' | t }}</h2>
+<h3 class="h4">{{ 'blogs.sidebar.recent_articles' | t }}</h3>
 <ul class="no-bullets">
   {% for article in blogs[blog.handle].articles limit:6 %}
     <li>
@@ -17,7 +17,7 @@
   Blog tags
 {% endcomment %}
 {% if blog.all_tags.size > 0 %}
-  <h2 class="h4">{{ 'blogs.sidebar.categories' | t }}</h2>
+  <h3 class="h4">{{ 'blogs.sidebar.categories' | t }}</h3>
   <ul class="no-bullets">
     {% for tag in blog.all_tags %}
       {% if current_tags contains tag %}

--- a/snippets/blog-sidebar.liquid
+++ b/snippets/blog-sidebar.liquid
@@ -2,7 +2,7 @@
 {% comment %}
   Recent blog posts
 {% endcomment %}
-<h4>{{ 'blogs.sidebar.recent_articles' | t }}</h4>
+<h2 class="h4">{{ 'blogs.sidebar.recent_articles' | t }}</h2>
 <ul class="no-bullets">
   {% for article in blogs[blog.handle].articles limit:6 %}
     <li>
@@ -17,7 +17,7 @@
   Blog tags
 {% endcomment %}
 {% if blog.all_tags.size > 0 %}
-  <h4>{{ 'blogs.sidebar.categories' | t }}</h4>
+  <h2 class="h4">{{ 'blogs.sidebar.categories' | t }}</h2>
   <ul class="no-bullets">
     {% for tag in blog.all_tags %}
       {% if current_tags contains tag %}

--- a/snippets/collection-sidebar.liquid
+++ b/snippets/collection-sidebar.liquid
@@ -14,7 +14,7 @@
   Product tags in the current collection
 {% endcomment %}
 {% if collection.all_tags.size > 0 %}
-  <h3>{{ 'collections.sidebar.tags' | t }}</h3>
+  <h2 class="h3">{{ 'collections.sidebar.tags' | t }}</h2>
 
   {% comment %}
     To provide a 'catch-all' link at the top of the list,

--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -68,7 +68,7 @@
     {% if blog.comments_enabled? %}
       <hr>
 
-      <h3>{{ 'blogs.comments.with_count' | t: count: number_of_comments }}</h3>
+      <h2 class="h3">{{ 'blogs.comments.with_count' | t: count: number_of_comments }}</h2>
 
       <hr>
 
@@ -129,7 +129,7 @@
 
           <div class="form-vertical">
             {% form 'new_comment', article %}
-              <h3>{{ 'blogs.comments.title' | t }}</h3>
+              <h2 class="h3">{{ 'blogs.comments.title' | t }}</h2>
 
               {{ form.errors | default_errors }}
 

--- a/templates/blog.liquid
+++ b/templates/blog.liquid
@@ -35,7 +35,7 @@
 
       <div class="article">
 
-        <h3><a href="{{ article.url }}">{{ article.title }}</a></h3>
+        <h2 class="h3"><a href="{{ article.url }}">{{ article.title }}</a></h2>
         {% capture author %}<strong>{{ article.author }}</strong>{% endcapture %}
         {% capture date %}<time datetime="{{ article.published_at | date: '%Y-%m-%d' }}">{{ article.published_at | date: format: 'month_day_year' }}</time>{% endcapture %}
         <p>{{ 'blogs.article.author_on_date_html' | t: author: author, date: date }}</p>

--- a/templates/customers/account.liquid
+++ b/templates/customers/account.liquid
@@ -13,7 +13,7 @@
 <div class="grid">
 
   <div class="grid__item two-thirds medium-down--one-whole">
-    <h4>{{ 'customer.orders.title' | t }}</h4>
+    <h2 class="h4">{{ 'customer.orders.title' | t }}</h2>
 
     {% comment %}
       If we have past orders, loop through each one
@@ -61,9 +61,9 @@
   </div>
 
   <div class="grid__item one-third medium-down--one-whole">
-    <h4>{{ 'customer.account.details' | t }}</h4>
+    <h2 class="h4">{{ 'customer.account.details' | t }}</h2>
 
-    <h5>{{ customer.name }}</h5>
+    <h3 class="h5">{{ customer.name }}</h3>
 
     {% if customer.default_address != nil %}
       <p>

--- a/templates/customers/order.liquid
+++ b/templates/customers/order.liquid
@@ -9,7 +9,7 @@
 <div class="grid">
 
   <div class="grid__item two-thirds medium-down--one-whole">
-    <h4>{{ 'customer.order.title' | t: name: order.name }}</h4>
+    <h2 class="h4">{{ 'customer.order.title' | t: name: order.name }}</h2>
 
     <p>{{ 'customer.order.date' | t: date: order.created_at | date: "%B %d, %Y %I:%M%p" }}</p>
 
@@ -93,11 +93,11 @@
 
   <div class="grid__item one-third medium-down--one-whole">
 
-    <h4>{{ 'customer.order.billing_address' | t }}</h4>
+    <h2 class="h4">{{ 'customer.order.billing_address' | t }}</h2>
 
     <p><strong>{{ 'customer.order.payment_status' | t }}:</strong> {{ order.financial_status_label }}</p>
 
-    <h5>{{ order.billing_address.name }}</h5>
+    <h3 class="h5">{{ order.billing_address.name }}</h3>
     <p>
       {% if order.billing_address.company != '' %}
         {{ order.billing_address.company }}<br>
@@ -112,11 +112,11 @@
       {{ order.billing_address.phone }}
     </p>
 
-    <h4>{{ 'customer.order.shipping_address' | t }}</h4>
+    <h2 class="h4">{{ 'customer.order.shipping_address' | t }}</h2>
 
     <p><strong>{{ 'customer.order.fulfillment_status' | t }}:</strong> {{ order.fulfillment_status_label }}</p>
 
-    <h5>{{ order.shipping_address.name }}</h5>
+    <h3 class="h5">{{ order.shipping_address.name }}</h3>
     <p>
       {% if order.shipping_address.company != '' %}
         {{ order.shipping_address.company }}<br>

--- a/templates/search.liquid
+++ b/templates/search.liquid
@@ -81,7 +81,7 @@
                     If we don't have a featured_image, add a push-- class to keep the alignment the same
                   {% endcomment %}
                   <div class="grid__item two-thirds {% unless item.featured_image %}push--one-third{% endunless %}">
-                    <h3>{{ item.title | link_to: item.url }}</h3>
+                    <h2 class="h3">{{ item.title | link_to: item.url }}</h2>
 
                     {% if item.price %}
                       <p>


### PR DESCRIPTION
Fix for https://github.com/Shopify/shopify-themes/issues/3527 (improving theme accessibility) and removed Stripe in credit cart payment whitelist.

**Demo: [link](http://timber-a11y.myshopify.com/?key=a0335d17c5dc8dbd88dc16199fc42229156bf8b8ba253d9d26aceb39170de2a4&preview_theme_id=110651457)**

cc @cshold @schaeken 👀  