### PR TITLE
Add StorefrontExpressButtons.initialize in cartCallback

### DIFF
--- a/assets/ajax-cart.js.liquid
+++ b/assets/ajax-cart.js.liquid
@@ -355,6 +355,10 @@ var ajaxCart = (function(module, $) {
   cartCallback = function(cart) {
     $body.removeClass('drawer--is-loading');
     $body.trigger('afterCartLoad.ajaxCart', cart);
+
+    if (window.Shopify && Shopify.StorefrontExpressButtons)
+      Shopify.StorefrontExpressButtons.initialize();
+    }
   };
 
   adjustCart = function () {


### PR DESCRIPTION
Themes using `ajax-cart` with Amazon Payments button are currently broken because of the script tag inserted along with the button.

Handlebars + script tag in template = 💥 

Let's add a callback after the cart has been updated where we can initialize every button needed on storefront.

@Krystosterone @cshold please review 👯 

Next step is modifying `shopify-themes` with these changes too. @cshold can you shed some light on the difference between `ajax-cart.js` and `ajaxify.js` in `shopify-themes` ?

*dont merge until https://github.com/Shopify/shopify/pull/80604*