### PR TITLE
[Timber] update a11y prices

### DIFF
--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -211,7 +211,6 @@ timber.productPage = function (options) {
       $productPrice = $('#ProductPrice'),
       $comparePrice = $('#ComparePrice'),
       $comparePriceA11y = $('#ComparePriceA11y'),
-      $priceA11y = $('#PriceA11y'),
       $quantityElements = $('.quantity-selector, label + .js-qty'),
       $addToCartText = $('#AddToCartText');
 
@@ -246,7 +245,6 @@ timber.productPage = function (options) {
         .html({{ 'products.product.compare_at' | t | json }} + ' ' + Shopify.formatMoney(variant.compare_at_price, moneyFormat))
         .show();
       $comparePriceA11y.attr('aria-hidden', 'false');
-      $priceA11y.attr('aria-hidden', 'false');
     } else {
       $comparePrice.hide();
       $comparePriceA11y.attr('aria-hidden', 'true');

--- a/assets/timber.js.liquid
+++ b/assets/timber.js.liquid
@@ -210,6 +210,8 @@ timber.productPage = function (options) {
       $addToCart = $('#AddToCart'),
       $productPrice = $('#ProductPrice'),
       $comparePrice = $('#ComparePrice'),
+      $comparePriceA11y = $('#ComparePriceA11y'),
+      $priceA11y = $('#PriceA11y'),
       $quantityElements = $('.quantity-selector, label + .js-qty'),
       $addToCartText = $('#AddToCartText');
 
@@ -243,8 +245,11 @@ timber.productPage = function (options) {
       $comparePrice
         .html({{ 'products.product.compare_at' | t | json }} + ' ' + Shopify.formatMoney(variant.compare_at_price, moneyFormat))
         .show();
+      $comparePriceA11y.attr('aria-hidden', 'false');
+      $priceA11y.attr('aria-hidden', 'false');
     } else {
       $comparePrice.hide();
+      $comparePriceA11y.attr('aria-hidden', 'true');
     }
 
   } else {

--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -76,6 +76,7 @@
         {% assign price = product.price | money %}
         {{ 'products.general.from_text_html' | t: price: price }}
       {% else %}
+        <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
         {{ product.price | money }}
       {% endif %}
     {% endif %}

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -90,13 +90,13 @@
             {% endfor %}
           </select>
 
-          <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
+          <span id="ComparePriceA11y" class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
           <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | divided_by: 100 }}">
             {{ current_variant.price | money }}
           </span>
 
           {% if product.compare_at_price_max > product.price %}
-            <span class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
+            <span id="PriceA11y" class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
             <p id="ComparePrice">
               {{ 'products.product.compare_at' | t }} {{ current_variant.compare_at_price | money }}
             </p>

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -90,13 +90,17 @@
             {% endfor %}
           </select>
 
-          <span id="ComparePriceA11y" class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
+          {% if product.compare_at_price_max > product.price %}
+            <span id="ComparePriceA11y" class="visually-hidden">{{ 'products.general.sale_price' | t }}</span>
+          {% else %}
+            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
+          {% endif %}
           <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | divided_by: 100 }}">
             {{ current_variant.price | money }}
           </span>
 
           {% if product.compare_at_price_max > product.price %}
-            <span id="PriceA11y" class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
+            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
             <p id="ComparePrice">
               {{ 'products.product.compare_at' | t }} {{ current_variant.compare_at_price | money }}
             </p>

--- a/templates/search.liquid
+++ b/templates/search.liquid
@@ -102,6 +102,7 @@
                             {% assign price = item.price | money %}
                             <span itemprop="price">{{ 'products.general.from_text_html' | t: price: price }}</span>
                           {% else %}
+                            <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
                             <span itemprop="price">{{ item.price | money }}</span>
                           {% endif %}
                         {% endif %}
@@ -109,7 +110,7 @@
                           <br><strong>{{ 'products.product.sold_out' | t }}</strong>
                         {% endif %}
                         {% if on_sale %}
-                          <br><span class="visually-hidden">{{ 'products.general.sale_price' | t }}</span><s>{{ item.compare_at_price | money }}</s>
+                          <br><span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span><s>{{ item.compare_at_price | money }}</s>
                         {% endif %}
                       </p>
                     {% endif %}


### PR DESCRIPTION
Fix for https://github.com/Shopify/shopify-themes/issues/3523

Did some cleanup - and organized better the a11y prices for screenreaders on the product grid, product and search page.

Demo: [link](http://timber-a11y.myshopify.com/?key=a0335d17c5dc8dbd88dc16199fc42229156bf8b8ba253d9d26aceb39170de2a4&preview_theme_id=121179265)

@ruairiphackett 👀 
cc @cshold 
