### PR TITLE
Fixed a nav menu draw open, then closed horizontal scroll bug

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -707,10 +707,12 @@ $class-type: unquote(".");
 ==============================================================================*/
 html {
   background-color: $colorFooterBg;
+  overflow-x: hidden !important;
 }
 
 body {
   background-color: $colorBody;
+  overflow-x: hidden !important;
 }
 
 [tabindex='-1']:focus {


### PR DESCRIPTION
Prior to bug fix, if you opened the nav menu then closed it without a
page reload, you would find a horizontal scroll on the main page with
overspill to the right hand side.