### PR TITLE
Fix structured data price rounding issue and usage warning

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -91,7 +91,7 @@
           </select>
 
           <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
-          <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | divided_by: 100 }}">
+          <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | money_without_currency | remove: ',' }}">
             {{ current_variant.price | money }}
           </span>
 

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -91,7 +91,7 @@
           </select>
 
           <span class="visually-hidden">{{ 'products.general.regular_price' | t }}</span>
-          <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | money_without_currency | remove: ',' }}">
+          <span id="ProductPrice" class="h2" itemprop="price" content="{{ current_variant.price | divided_by: 100.00 }}">
             {{ current_variant.price | money }}
           </span>
 


### PR DESCRIPTION
~~Fix rounding issue caused by using `divided_by` Math filter.~~
~~> Divides an output by a number. The output is rounded down to the nearest integer.~~

~~i.e. 3499.95 was being rounded down to 3499~~
~~See: https://help.shopify.com/themes/liquid/filters/math-filters#divided_by~~


~~Bring `price` implementation inline with usage guidelines. No longer produces warning in Google's Structured Data Testing Tool for values greater than 999.99 that use comma separator for readability.~~

~~> Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.~~

~~See: http://schema.org/price~~

Updated pull request based on solution in comments provided by @cshold 

