### PR TITLE
Remove deprecated named size parameters from social-meta-tags.liquid

### DIFF
--- a/snippets/social-meta-tags.liquid
+++ b/snippets/social-meta-tags.liquid
@@ -10,8 +10,8 @@
   <meta property="og:type" content="product">
   <meta property="og:title" content="{{ product.title | strip_html | escape }}">
   {% for image in product.images reversed limit:3 %}
-    <meta property="og:image" content="http:{{ image | img_url: 'grande' }}">
-    <meta property="og:image:secure_url" content="https:{{ image | img_url: 'grande' }}">
+    <meta property="og:image" content="http:{{ image | img_url: '600x600' }}">
+    <meta property="og:image:secure_url" content="https:{{ image | img_url: '600x600' }}">
   {% endfor %}
   <meta property="og:description" content="{{ product.description | strip_html | escape }}">
   <meta property="og:price:amount" content="{{ product.price | money_without_currency | strip_html | escape }}">
@@ -52,7 +52,7 @@
 {% elsif template contains 'product' %}
   <meta name="twitter:title" content="{{ product.title | strip_html | escape }}">
   <meta name="twitter:description" content="{{ product.description | strip_html | truncate: 200, '' | escape }}">
-  <meta name="twitter:image" content="https:{{ product | img_url: 'grande' }}">
+  <meta name="twitter:image" content="https:{{ product | img_url: '600x600' }}">
   <meta name="twitter:image:width" content="600">
   <meta name="twitter:image:height" content="600">
 {% elsif template contains 'article' %}


### PR DESCRIPTION
As stated in the docs, named image sizes are deprecated.
See: https://help.shopify.com/themes/liquid/filters/url-filters#named-size-parameters