### PR TITLE
Disable ajax request caching to enable ajaxCart in IE (#599)

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -416,6 +416,8 @@
     {% include 'ajax-cart-template' %}
     {{ 'ajax-cart.js' | asset_url | script_tag }}
     <script>
+      $.ajaxSetup({ cache: false });
+
       jQuery(function($) {
         ajaxCart.init({
           formSelector: '#AddToCartForm',


### PR DESCRIPTION
As per #599, "Add To Cart" buttons were working but not triggering ajaxCart drawer animations or updates in Internet Explorer. Setting `cache` to `false` seems to fix this with no adverse effects. Tested in all modern browser/OS combinations.